### PR TITLE
feat: add create_bucket_with_storage with automatic provider matching

### DIFF
--- a/pallet/src/benchmarking.rs
+++ b/pallet/src/benchmarking.rs
@@ -185,6 +185,20 @@ mod benchmarks {
     }
 
     #[benchmark]
+    fn create_bucket_with_storage() {
+        // Create a provider first
+        let _provider = create_provider::<T>(0);
+        let admin = funded_account::<T>("admin", 1);
+
+        let max_bytes = 1_000u64;
+        let duration: BlockNumberFor<T> = 100u32.into();
+        let max_price_per_byte: BalanceOf<T> = 1000u32.into();
+
+        #[extrinsic_call]
+        create_bucket_with_storage(RawOrigin::Signed(admin), max_bytes, duration, max_price_per_byte);
+    }
+
+    #[benchmark]
     fn set_bucket_min_providers() {
         let admin = funded_account::<T>("admin", 0);
         let bucket_id = setup_bucket::<T>(&admin);

--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -772,6 +772,10 @@ pub mod pallet {
         WithinGracePeriod,
         /// No rewards to claim.
         NoRewardsToClaim,
+
+        // Auto-matching errors
+        /// No provider found matching the storage requirements.
+        NoMatchingProvider,
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -1013,6 +1017,116 @@ pub mod pallet {
             Self::deposit_event(Event::BucketCreated {
                 bucket_id,
                 admin: who,
+            });
+
+            Ok(())
+        }
+
+        /// Create a new bucket with storage requirements and auto-match to a provider.
+        ///
+        /// This is the preferred way to create a bucket with storage. The system
+        /// automatically finds a matching provider based on your requirements and
+        /// creates both the bucket and agreement in one atomic operation.
+        ///
+        /// Providers who set `accepting_primary: true` have pre-consented to accepting
+        /// agreements within their stated parameters (capacity, price, duration).
+        #[pallet::call_index(16)]
+        #[pallet::weight(T::WeightInfo::create_bucket_with_storage())]
+        pub fn create_bucket_with_storage(
+            origin: OriginFor<T>,
+            max_bytes: u64,
+            duration: BlockNumberFor<T>,
+            max_price_per_byte: BalanceOf<T>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // Find a matching provider
+            let (provider, provider_info) =
+                Self::find_matching_provider(max_bytes, duration, max_price_per_byte)?;
+
+            // Calculate payment using provider's actual price
+            let payment = Self::calculate_payment(
+                provider_info.settings.price_per_byte,
+                max_bytes,
+                duration,
+            )?;
+
+            // Reserve funds from caller
+            T::Currency::reserve(&who, payment)?;
+
+            // Create the bucket
+            let bucket_id = NextBucketId::<T>::get();
+            NextBucketId::<T>::put(bucket_id.saturating_add(1));
+
+            let admin_member = Member {
+                account: who.clone(),
+                role: Role::Admin,
+            };
+
+            let mut members = BoundedVec::new();
+            members
+                .try_push(admin_member)
+                .map_err(|_| Error::<T>::MaxMembersReached)?;
+
+            let mut primary_providers = BoundedVec::new();
+            primary_providers
+                .try_push(provider.clone())
+                .map_err(|_| Error::<T>::MaxPrimaryProvidersReached)?;
+
+            let bucket = Bucket {
+                members,
+                frozen_start_seq: None,
+                min_providers: 1,
+                primary_providers,
+                snapshot: None,
+                historical_roots: [(0, H256::zero()); 6],
+                total_snapshots: 0,
+            };
+
+            Buckets::<T>::insert(bucket_id, bucket);
+
+            // Create the agreement
+            let current_block = frame_system::Pallet::<T>::block_number();
+            let expires_at = current_block.saturating_add(duration);
+
+            let agreement = StorageAgreement {
+                owner: who.clone(),
+                max_bytes,
+                payment_locked: payment,
+                price_per_byte: provider_info.settings.price_per_byte,
+                expires_at,
+                extensions_blocked: false,
+                role: ProviderRole::Primary,
+                started_at: current_block,
+            };
+
+            // Update provider's committed_bytes
+            Providers::<T>::mutate(&provider, |maybe_provider| {
+                if let Some(provider_info) = maybe_provider {
+                    provider_info.committed_bytes =
+                        provider_info.committed_bytes.saturating_add(max_bytes);
+                    provider_info.stats.agreements_total =
+                        provider_info.stats.agreements_total.saturating_add(1);
+                }
+            });
+
+            StorageAgreements::<T>::insert(bucket_id, &provider, agreement);
+
+            // Emit events
+            Self::deposit_event(Event::BucketCreated {
+                bucket_id,
+                admin: who.clone(),
+            });
+
+            Self::deposit_event(Event::AgreementAccepted {
+                bucket_id,
+                provider: provider.clone(),
+                expires_at,
+            });
+
+            Self::deposit_event(Event::ProviderAddedToBucket {
+                bucket_id,
+                provider,
             });
 
             Ok(())
@@ -2932,6 +3046,79 @@ pub mod pallet {
                 .checked_mul(&bytes_balance)
                 .and_then(|p| p.checked_mul(&duration_balance))
                 .ok_or(Error::<T>::ArithmeticOverflow.into())
+        }
+
+        /// Find a provider matching the storage requirements.
+        ///
+        /// Returns the best matching provider that:
+        /// - Is accepting primary agreements
+        /// - Has sufficient available capacity
+        /// - Has price at or below max_price_per_byte
+        /// - Accepts the requested duration
+        /// - Has sufficient stake to back the additional bytes
+        fn find_matching_provider(
+            bytes_needed: u64,
+            duration: BlockNumberFor<T>,
+            max_price_per_byte: BalanceOf<T>,
+        ) -> Result<(T::AccountId, ProviderInfo<T>), DispatchError> {
+            use sp_runtime::traits::SaturatedConversion;
+
+            let mut best_match: Option<(T::AccountId, ProviderInfo<T>, BalanceOf<T>)> = None;
+
+            for (account, info) in Providers::<T>::iter() {
+                // Must be accepting primary agreements
+                if !info.settings.accepting_primary {
+                    continue;
+                }
+
+                // Check duration constraints
+                if duration < info.settings.min_duration || duration > info.settings.max_duration {
+                    continue;
+                }
+
+                // Check price constraint
+                if info.settings.price_per_byte > max_price_per_byte {
+                    continue;
+                }
+
+                // Check capacity constraint
+                let max_capacity = info.settings.max_capacity;
+                if max_capacity > 0 {
+                    let available = max_capacity.saturating_sub(info.committed_bytes);
+                    if available < bytes_needed {
+                        continue;
+                    }
+                }
+
+                // Check stake constraint (can they back the additional bytes?)
+                let new_committed = info.committed_bytes.saturating_add(bytes_needed);
+                let bytes_as_balance: BalanceOf<T> = new_committed.saturated_into();
+                if let Some(required_stake) =
+                    T::MinStakePerByte::get().checked_mul(&bytes_as_balance)
+                {
+                    if info.stake < required_stake {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+
+                // This provider matches! Track best by lowest price
+                let price = info.settings.price_per_byte;
+                match &best_match {
+                    None => {
+                        best_match = Some((account, info, price));
+                    }
+                    Some((_, _, best_price)) if price < *best_price => {
+                        best_match = Some((account, info, price));
+                    }
+                    _ => {}
+                }
+            }
+
+            best_match
+                .map(|(account, info, _)| (account, info))
+                .ok_or(Error::<T>::NoMatchingProvider.into())
         }
 
         fn finalize_agreement(

--- a/pallet/src/tests.rs
+++ b/pallet/src/tests.rs
@@ -916,3 +916,294 @@ mod agreement_tests {
         });
     }
 }
+
+mod auto_matching_tests {
+    use super::*;
+
+    #[test]
+    fn create_bucket_with_storage_works() {
+        new_test_ext().execute_with(|| {
+            // Register a provider with accepting_primary: true
+            let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
+            assert_ok!(StorageProvider::register_provider(
+                RuntimeOrigin::signed(2),
+                multiaddr.try_into().unwrap(),
+                test_public_key(),
+                200
+            ));
+
+            // Update settings to accept primary agreements
+            // Use price_per_byte: 0 like other tests to avoid balance issues
+            let settings = ProviderSettings {
+                min_duration: 10u64,
+                max_duration: 1000u64,
+                price_per_byte: 0u64, // Free storage (like other tests)
+                accepting_primary: true,
+                replica_sync_price: None,
+                accepting_extensions: true,
+                max_capacity: 200,
+            };
+            assert_ok!(StorageProvider::update_provider_settings(
+                RuntimeOrigin::signed(2),
+                settings
+            ));
+
+            // Create bucket with storage requirements
+            assert_ok!(StorageProvider::create_bucket_with_storage(
+                RuntimeOrigin::signed(1),
+                100,  // max_bytes
+                100,  // duration
+                10    // max_price_per_byte (higher than provider's price of 0)
+            ));
+
+            // Verify bucket was created
+            let bucket = Buckets::<Test>::get(0).unwrap();
+            assert_eq!(bucket.min_providers, 1);
+            assert_eq!(bucket.primary_providers.len(), 1);
+            assert_eq!(bucket.primary_providers[0], 2);
+
+            // Verify agreement was created
+            let agreement = StorageAgreements::<Test>::get(0, 2).unwrap();
+            assert_eq!(agreement.max_bytes, 100);
+            assert_eq!(agreement.owner, 1);
+
+            // Verify provider's committed_bytes was updated
+            let provider = Providers::<Test>::get(2).unwrap();
+            assert_eq!(provider.committed_bytes, 100);
+        });
+    }
+
+    #[test]
+    fn create_bucket_with_storage_fails_no_matching_provider() {
+        new_test_ext().execute_with(|| {
+            // No providers registered
+            assert_noop!(
+                StorageProvider::create_bucket_with_storage(
+                    RuntimeOrigin::signed(1),
+                    100,
+                    100,
+                    10
+                ),
+                Error::<Test>::NoMatchingProvider
+            );
+        });
+    }
+
+    #[test]
+    fn create_bucket_with_storage_fails_provider_not_accepting() {
+        new_test_ext().execute_with(|| {
+            // Register a provider but don't set accepting_primary: true
+            let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
+            assert_ok!(StorageProvider::register_provider(
+                RuntimeOrigin::signed(2),
+                multiaddr.try_into().unwrap(),
+                test_public_key(),
+                200
+            ));
+
+            // Settings have accepting_primary: false by default (need to explicitly enable)
+            // Since default is accepting_primary: true, let's set it to false
+            let settings = ProviderSettings {
+                min_duration: 10u64,
+                max_duration: 1000u64,
+                price_per_byte: 1u64,
+                accepting_primary: false, // Not accepting
+                replica_sync_price: None,
+                accepting_extensions: true,
+                max_capacity: 200,
+            };
+            assert_ok!(StorageProvider::update_provider_settings(
+                RuntimeOrigin::signed(2),
+                settings
+            ));
+
+            assert_noop!(
+                StorageProvider::create_bucket_with_storage(
+                    RuntimeOrigin::signed(1),
+                    100,
+                    100,
+                    10
+                ),
+                Error::<Test>::NoMatchingProvider
+            );
+        });
+    }
+
+    #[test]
+    fn create_bucket_with_storage_fails_price_too_high() {
+        new_test_ext().execute_with(|| {
+            let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
+            assert_ok!(StorageProvider::register_provider(
+                RuntimeOrigin::signed(2),
+                multiaddr.try_into().unwrap(),
+                test_public_key(),
+                200
+            ));
+
+            // Provider with high price
+            let settings = ProviderSettings {
+                min_duration: 10u64,
+                max_duration: 1000u64,
+                price_per_byte: 100u64, // Very high price
+                accepting_primary: true,
+                replica_sync_price: None,
+                accepting_extensions: true,
+                max_capacity: 200,
+            };
+            assert_ok!(StorageProvider::update_provider_settings(
+                RuntimeOrigin::signed(2),
+                settings
+            ));
+
+            // User's max_price_per_byte is lower than provider's price
+            assert_noop!(
+                StorageProvider::create_bucket_with_storage(
+                    RuntimeOrigin::signed(1),
+                    100,
+                    100,
+                    10 // max_price_per_byte is 10, but provider charges 100
+                ),
+                Error::<Test>::NoMatchingProvider
+            );
+        });
+    }
+
+    #[test]
+    fn create_bucket_with_storage_fails_insufficient_capacity() {
+        new_test_ext().execute_with(|| {
+            let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
+            assert_ok!(StorageProvider::register_provider(
+                RuntimeOrigin::signed(2),
+                multiaddr.try_into().unwrap(),
+                test_public_key(),
+                200
+            ));
+
+            let settings = ProviderSettings {
+                min_duration: 10u64,
+                max_duration: 1000u64,
+                price_per_byte: 1u64,
+                accepting_primary: true,
+                replica_sync_price: None,
+                accepting_extensions: true,
+                max_capacity: 50, // Only 50 bytes capacity
+            };
+            assert_ok!(StorageProvider::update_provider_settings(
+                RuntimeOrigin::signed(2),
+                settings
+            ));
+
+            // Request 100 bytes, but provider only has 50
+            assert_noop!(
+                StorageProvider::create_bucket_with_storage(
+                    RuntimeOrigin::signed(1),
+                    100, // Needs 100 bytes
+                    100,
+                    10
+                ),
+                Error::<Test>::NoMatchingProvider
+            );
+        });
+    }
+
+    #[test]
+    fn create_bucket_with_storage_fails_duration_mismatch() {
+        new_test_ext().execute_with(|| {
+            let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
+            assert_ok!(StorageProvider::register_provider(
+                RuntimeOrigin::signed(2),
+                multiaddr.try_into().unwrap(),
+                test_public_key(),
+                200
+            ));
+
+            let settings = ProviderSettings {
+                min_duration: 500u64, // Minimum 500 blocks
+                max_duration: 1000u64,
+                price_per_byte: 1u64,
+                accepting_primary: true,
+                replica_sync_price: None,
+                accepting_extensions: true,
+                max_capacity: 200,
+            };
+            assert_ok!(StorageProvider::update_provider_settings(
+                RuntimeOrigin::signed(2),
+                settings
+            ));
+
+            // Request only 100 blocks, but provider requires minimum 500
+            assert_noop!(
+                StorageProvider::create_bucket_with_storage(
+                    RuntimeOrigin::signed(1),
+                    100,
+                    100, // Duration of 100, below provider's min of 500
+                    10
+                ),
+                Error::<Test>::NoMatchingProvider
+            );
+        });
+    }
+
+    #[test]
+    fn create_bucket_with_storage_selects_cheapest_provider() {
+        new_test_ext().execute_with(|| {
+            // Register two providers with different prices
+            let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
+
+            // Provider 2: expensive (price = 5) - but still affordable
+            assert_ok!(StorageProvider::register_provider(
+                RuntimeOrigin::signed(2),
+                multiaddr.clone().try_into().unwrap(),
+                test_public_key(),
+                200
+            ));
+            let settings_expensive = ProviderSettings {
+                min_duration: 10u64,
+                max_duration: 1000u64,
+                price_per_byte: 5u64,
+                accepting_primary: true,
+                replica_sync_price: None,
+                accepting_extensions: true,
+                max_capacity: 200,
+            };
+            assert_ok!(StorageProvider::update_provider_settings(
+                RuntimeOrigin::signed(2),
+                settings_expensive
+            ));
+
+            // Provider 3: cheap (price = 0)
+            assert_ok!(StorageProvider::register_provider(
+                RuntimeOrigin::signed(3),
+                multiaddr.try_into().unwrap(),
+                test_public_key(),
+                200
+            ));
+            let settings_cheap = ProviderSettings {
+                min_duration: 10u64,
+                max_duration: 1000u64,
+                price_per_byte: 0u64, // Free
+                accepting_primary: true,
+                replica_sync_price: None,
+                accepting_extensions: true,
+                max_capacity: 200,
+            };
+            assert_ok!(StorageProvider::update_provider_settings(
+                RuntimeOrigin::signed(3),
+                settings_cheap
+            ));
+
+            // Create bucket - should match with cheaper provider (3)
+            // Use small values to keep payment low: 10 * 10 * 5 = 500 max
+            assert_ok!(StorageProvider::create_bucket_with_storage(
+                RuntimeOrigin::signed(1),
+                10,  // max_bytes
+                10,  // duration
+                10   // max_price_per_byte
+            ));
+
+            // Verify matched with provider 3 (the cheaper one)
+            let bucket = Buckets::<Test>::get(0).unwrap();
+            assert_eq!(bucket.primary_providers[0], 3);
+        });
+    }
+}

--- a/pallet/src/weights.rs
+++ b/pallet/src/weights.rs
@@ -22,6 +22,7 @@ pub trait WeightInfo {
 
     // Bucket management
     fn create_bucket() -> Weight;
+    fn create_bucket_with_storage() -> Weight;
     fn delete_bucket() -> Weight;
     fn set_bucket_member() -> Weight;
     fn remove_bucket_member() -> Weight;
@@ -106,6 +107,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
         Weight::from_parts(45_000_000, 4500)
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+
+    fn create_bucket_with_storage() -> Weight {
+        // Heavier than create_bucket: iterates providers, creates agreement
+        Weight::from_parts(120_000_000, 12000)
+            .saturating_add(T::DbWeight::get().reads(10_u64))
+            .saturating_add(T::DbWeight::get().writes(5_u64))
     }
 
     fn delete_bucket() -> Weight {
@@ -312,6 +320,7 @@ impl WeightInfo for () {
     fn add_stake() -> Weight { Weight::from_parts(10_000, 0) }
     fn update_provider_multiaddr() -> Weight { Weight::from_parts(10_000, 0) }
     fn create_bucket() -> Weight { Weight::from_parts(10_000, 0) }
+    fn create_bucket_with_storage() -> Weight { Weight::from_parts(10_000, 0) }
     fn delete_bucket() -> Weight { Weight::from_parts(10_000, 0) }
     fn set_bucket_member() -> Weight { Weight::from_parts(10_000, 0) }
     fn remove_bucket_member() -> Weight { Weight::from_parts(10_000, 0) }


### PR DESCRIPTION
## Summary

- Adds new `create_bucket_with_storage` extrinsic that allows users to create buckets with storage requirements and have the system automatically match them to a suitable provider
- Eliminates the manual request/accept dance for agreements - providers pre-consent by setting `accepting_primary: true`
- Selects the cheapest matching provider when multiple qualify

## Changes

- New extrinsic `create_bucket_with_storage(max_bytes, duration, max_price_per_byte)` with call_index 16
- `find_matching_provider` helper function that filters by: accepting status, capacity, price, duration, and stake
- Added `NoMatchingProvider` error
- 7 new tests covering success and error cases
- Added benchmark for the new extrinsic

## Test plan

- [x] All 41 pallet tests pass (`cargo test -p pallet-storage-provider`)
- [x] Runtime compiles successfully (`cargo check -p storage-parachain-runtime`)
- [ ] Manual testing with local chain