### PR TITLE
chore: simplify S3 interface and provider dashboard code

### DIFF
--- a/storage-interfaces/s3/client/src/lib.rs
+++ b/storage-interfaces/s3/client/src/lib.rs
@@ -186,16 +186,8 @@ impl S3Client {
             return Err(S3ClientError::InvalidBucketName(name.to_string()));
         }
 
-        if self
-            .substrate_client
-            .get_bucket_id_by_name(name)
-            .await?
-            .is_some()
-        {
-            return Err(S3ClientError::BucketAlreadyExists(name.to_string()));
-        }
-
         // Create S3 bucket (Layer 0 bucket is created internally by the pallet)
+        // The pallet validates name uniqueness, so no need to pre-check.
         let s3_bucket_id = self
             .substrate_client
             .create_s3_bucket(name, min_providers)
@@ -406,18 +398,8 @@ impl S3Client {
             src_bucket, src_key, dst_bucket, dst_key
         );
 
-        let src_bucket_info = self.head_bucket(src_bucket).await?;
-        let dst_bucket_info = self.head_bucket(dst_bucket).await?;
-
-        let src_metadata = self
-            .substrate_client
-            .get_object_metadata(src_bucket_info.s3_bucket_id, src_key)
-            .await
-            .map_err(|e| S3ClientError::ChainError(e.to_string()))?
-            .ok_or_else(|| S3ClientError::ObjectNotFound {
-                bucket: src_bucket.to_string(),
-                key: src_key.to_string(),
-            })?;
+        let (src_bucket_info, dst_bucket_info) =
+            tokio::try_join!(self.head_bucket(src_bucket), self.head_bucket(dst_bucket))?;
 
         self.substrate_client
             .copy_object_metadata(
@@ -429,15 +411,26 @@ impl S3Client {
             .await
             .map_err(|e| S3ClientError::ChainError(e.to_string()))?;
 
+        // Read the copied object's metadata from the destination
+        let dst_metadata = self
+            .substrate_client
+            .get_object_metadata(dst_bucket_info.s3_bucket_id, dst_key)
+            .await
+            .map_err(|e| S3ClientError::ChainError(e.to_string()))?
+            .ok_or_else(|| S3ClientError::ObjectNotFound {
+                bucket: dst_bucket.to_string(),
+                key: dst_key.to_string(),
+            })?;
+
         info!(
             "Object copied: {}/{} -> {}/{}",
             src_bucket, src_key, dst_bucket, dst_key
         );
 
         Ok(PutObjectResponse {
-            etag: String::from_utf8_lossy(&src_metadata.etag).to_string(),
-            cid: src_metadata.cid,
-            size: src_metadata.size,
+            etag: String::from_utf8_lossy(&dst_metadata.etag).to_string(),
+            cid: dst_metadata.cid,
+            size: dst_metadata.size,
         })
     }
 

--- a/storage-interfaces/s3/client/src/substrate.rs
+++ b/storage-interfaces/s3/client/src/substrate.rs
@@ -9,6 +9,9 @@ use subxt::{OnlineClient, PolkadotConfig};
 use subxt_signer::sr25519::Keypair;
 use tracing::{debug, info};
 
+/// Pallet name in the runtime configuration.
+const PALLET_NAME: &str = "S3Registry";
+
 /// Object metadata from chain storage.
 #[derive(Clone, Debug)]
 pub struct ChainObjectMetadata {
@@ -89,6 +92,22 @@ impl SubstrateClient {
             .ok_or_else(|| "No signer configured".to_string())
     }
 
+    /// Sign, submit, and wait for a transaction to finalize successfully.
+    async fn submit_and_finalize(
+        &self,
+        tx: subxt::tx::DefaultPayload<Composite<()>>,
+    ) -> std::result::Result<subxt::blocks::ExtrinsicEvents<PolkadotConfig>, String> {
+        let signer = self.signer()?;
+        self.client
+            .tx()
+            .sign_and_submit_then_watch_default(&tx, signer)
+            .await
+            .map_err(|e| format!("Failed to submit tx: {e}"))?
+            .wait_for_finalized_success()
+            .await
+            .map_err(|e| format!("Transaction failed: {e}"))
+    }
+
     /// Create an S3 bucket.
     ///
     /// This creates both the Layer 0 bucket and the S3 bucket in a single transaction.
@@ -104,7 +123,7 @@ impl SubstrateClient {
         );
 
         let tx = subxt::dynamic::tx(
-            "S3Registry",
+            PALLET_NAME,
             "create_s3_bucket",
             vec![
                 Value::from_bytes(name.as_bytes()),
@@ -112,22 +131,11 @@ impl SubstrateClient {
             ],
         );
 
-        let signer = self.signer()?;
-        let progress = self
-            .client
-            .tx()
-            .sign_and_submit_then_watch_default(&tx, signer)
-            .await
-            .map_err(|e| format!("Failed to submit tx: {e}"))?;
-
-        let events = progress
-            .wait_for_finalized_success()
-            .await
-            .map_err(|e| format!("Transaction failed: {e}"))?;
+        let events = self.submit_and_finalize(tx).await?;
 
         // Try to extract bucket ID from event
         for event in events.iter().flatten() {
-            if event.pallet_name() == "S3Registry" && event.variant_name() == "S3BucketCreated" {
+            if event.pallet_name() == PALLET_NAME && event.variant_name() == "S3BucketCreated" {
                 if let Ok(values) = event.field_values() {
                     if let Some(id) = values.at("s3_bucket_id").and_then(|v| v.as_u128()) {
                         return Ok(id as u64);
@@ -148,24 +156,12 @@ impl SubstrateClient {
         debug!("Deleting S3 bucket: {}", bucket_id);
 
         let tx = subxt::dynamic::tx(
-            "S3Registry",
+            PALLET_NAME,
             "delete_s3_bucket",
             vec![Value::u128(bucket_id as u128)],
         );
 
-        let signer = self.signer()?;
-        let progress = self
-            .client
-            .tx()
-            .sign_and_submit_then_watch_default(&tx, signer)
-            .await
-            .map_err(|e| format!("Failed to submit tx: {e}"))?;
-
-        progress
-            .wait_for_finalized_success()
-            .await
-            .map_err(|e| format!("Transaction failed: {e}"))?;
-
+        self.submit_and_finalize(tx).await?;
         Ok(())
     }
 
@@ -188,7 +184,7 @@ impl SubstrateClient {
             .collect();
 
         let tx = subxt::dynamic::tx(
-            "S3Registry",
+            PALLET_NAME,
             "put_object_metadata",
             vec![
                 Value::u128(bucket_id as u128),
@@ -200,19 +196,7 @@ impl SubstrateClient {
             ],
         );
 
-        let signer = self.signer()?;
-        let progress = self
-            .client
-            .tx()
-            .sign_and_submit_then_watch_default(&tx, signer)
-            .await
-            .map_err(|e| format!("Failed to submit tx: {e}"))?;
-
-        progress
-            .wait_for_finalized_success()
-            .await
-            .map_err(|e| format!("Transaction failed: {e}"))?;
-
+        self.submit_and_finalize(tx).await?;
         Ok(())
     }
 
@@ -228,7 +212,7 @@ impl SubstrateClient {
         );
 
         let tx = subxt::dynamic::tx(
-            "S3Registry",
+            PALLET_NAME,
             "delete_object_metadata",
             vec![
                 Value::u128(bucket_id as u128),
@@ -236,19 +220,7 @@ impl SubstrateClient {
             ],
         );
 
-        let signer = self.signer()?;
-        let progress = self
-            .client
-            .tx()
-            .sign_and_submit_then_watch_default(&tx, signer)
-            .await
-            .map_err(|e| format!("Failed to submit tx: {e}"))?;
-
-        progress
-            .wait_for_finalized_success()
-            .await
-            .map_err(|e| format!("Transaction failed: {e}"))?;
-
+        self.submit_and_finalize(tx).await?;
         Ok(())
     }
 
@@ -266,7 +238,7 @@ impl SubstrateClient {
         );
 
         let tx = subxt::dynamic::tx(
-            "S3Registry",
+            PALLET_NAME,
             "copy_object_metadata",
             vec![
                 Value::u128(src_bucket_id as u128),
@@ -276,19 +248,7 @@ impl SubstrateClient {
             ],
         );
 
-        let signer = self.signer()?;
-        let progress = self
-            .client
-            .tx()
-            .sign_and_submit_then_watch_default(&tx, signer)
-            .await
-            .map_err(|e| format!("Failed to submit tx: {e}"))?;
-
-        progress
-            .wait_for_finalized_success()
-            .await
-            .map_err(|e| format!("Transaction failed: {e}"))?;
-
+        self.submit_and_finalize(tx).await?;
         Ok(())
     }
 
@@ -298,7 +258,7 @@ impl SubstrateClient {
         name: &str,
     ) -> std::result::Result<Option<S3BucketId>, S3ClientError> {
         let storage_query = subxt::dynamic::storage(
-            "S3Registry",
+            PALLET_NAME,
             "BucketNameToId",
             vec![Value::from_bytes(name.as_bytes())],
         );
@@ -322,7 +282,7 @@ impl SubstrateClient {
         bucket_id: S3BucketId,
     ) -> std::result::Result<Option<BucketInfo>, String> {
         let storage_query = subxt::dynamic::storage(
-            "S3Registry",
+            PALLET_NAME,
             "S3Buckets",
             vec![Value::u128(bucket_id as u128)],
         );
@@ -367,7 +327,7 @@ impl SubstrateClient {
         key: &str,
     ) -> std::result::Result<Option<ChainObjectMetadata>, String> {
         let storage_query = subxt::dynamic::storage(
-            "S3Registry",
+            PALLET_NAME,
             "Objects",
             vec![
                 Value::u128(bucket_id as u128),
@@ -419,7 +379,7 @@ impl SubstrateClient {
     /// List user's buckets.
     pub async fn list_user_buckets(&self) -> std::result::Result<Vec<BucketInfo>, String> {
         let storage_query = subxt::dynamic::storage(
-            "S3Registry",
+            PALLET_NAME,
             "UserBuckets",
             vec![Value::from_bytes(self.account_id)],
         );

--- a/storage-interfaces/s3/pallet-s3-registry/src/lib.rs
+++ b/storage-interfaces/s3/pallet-s3-registry/src/lib.rs
@@ -314,16 +314,15 @@ pub mod pallet {
             let timestamp = frame_system::Pallet::<T>::block_number().saturated_into::<u64>();
 
             // Check if this is an update or new object
-            let is_new = !Objects::<T>::contains_key(s3_bucket_id, &bounded_key);
-            if is_new {
-                ensure!(
-                    bucket_info.object_count < T::MaxObjectsPerBucket::get() as u64,
-                    Error::<T>::TooManyObjects
-                );
-                bucket_info.object_count = bucket_info.object_count.saturating_add(1);
-            } else {
-                // Subtract old size
-                if let Some(old_metadata) = Objects::<T>::get(s3_bucket_id, &bounded_key) {
+            match Objects::<T>::get(s3_bucket_id, &bounded_key) {
+                None => {
+                    ensure!(
+                        bucket_info.object_count < T::MaxObjectsPerBucket::get() as u64,
+                        Error::<T>::TooManyObjects
+                    );
+                    bucket_info.object_count = bucket_info.object_count.saturating_add(1);
+                }
+                Some(old_metadata) => {
                     bucket_info.total_size =
                         bucket_info.total_size.saturating_sub(old_metadata.size);
                 }
@@ -409,7 +408,7 @@ pub mod pallet {
             ensure!(src_bucket.owner == who, Error::<T>::NotBucketOwner);
 
             // Verify destination bucket ownership
-            let mut dst_bucket =
+            let dst_bucket =
                 S3Buckets::<T>::get(dst_bucket_id).ok_or(Error::<T>::BucketNotFound)?;
             ensure!(dst_bucket.owner == who, Error::<T>::NotBucketOwner);
 
@@ -431,16 +430,21 @@ pub mod pallet {
             metadata.last_modified =
                 frame_system::Pallet::<T>::block_number().saturated_into::<u64>();
 
-            // Check if destination exists (for stats update)
-            let dst_is_new = !Objects::<T>::contains_key(dst_bucket_id, &bounded_dst_key);
-            if dst_is_new {
-                ensure!(
-                    dst_bucket.object_count < T::MaxObjectsPerBucket::get() as u64,
-                    Error::<T>::TooManyObjects
-                );
-                dst_bucket.object_count = dst_bucket.object_count.saturating_add(1);
-            } else if let Some(old) = Objects::<T>::get(dst_bucket_id, &bounded_dst_key) {
-                dst_bucket.total_size = dst_bucket.total_size.saturating_sub(old.size);
+            // Update destination bucket stats (re-read if same bucket since src was read separately)
+            let mut dst_bucket =
+                S3Buckets::<T>::get(dst_bucket_id).ok_or(Error::<T>::BucketNotFound)?;
+
+            match Objects::<T>::get(dst_bucket_id, &bounded_dst_key) {
+                None => {
+                    ensure!(
+                        dst_bucket.object_count < T::MaxObjectsPerBucket::get() as u64,
+                        Error::<T>::TooManyObjects
+                    );
+                    dst_bucket.object_count = dst_bucket.object_count.saturating_add(1);
+                }
+                Some(old) => {
+                    dst_bucket.total_size = dst_bucket.total_size.saturating_sub(old.size);
+                }
             }
 
             dst_bucket.total_size = dst_bucket.total_size.saturating_add(metadata.size);

--- a/user-interfaces/provider/src/components/RequireProvider.tsx
+++ b/user-interfaces/provider/src/components/RequireProvider.tsx
@@ -1,0 +1,37 @@
+import { type ReactNode } from 'react'
+import { type LucideIcon } from 'lucide-react'
+import { useSelectedAccount } from '@/state/wallet.state'
+import { useIsRegistered } from '@/state/provider.state'
+
+interface RequireProviderProps {
+  icon: LucideIcon
+  pageName: string
+  children: ReactNode
+}
+
+export function RequireProvider({ icon: Icon, pageName, children }: RequireProviderProps) {
+  const selectedAccount = useSelectedAccount()
+  const isRegistered = useIsRegistered()
+
+  if (!selectedAccount) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16">
+        <Icon className="h-16 w-16 text-gray-600 mb-4" />
+        <h2 className="text-xl font-semibold text-gray-300 mb-2">Connect Your Wallet</h2>
+        <p className="text-gray-500">Connect a wallet to view {pageName}</p>
+      </div>
+    )
+  }
+
+  if (!isRegistered) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16">
+        <Icon className="h-16 w-16 text-gray-600 mb-4" />
+        <h2 className="text-xl font-semibold text-gray-300 mb-2">Not Registered</h2>
+        <p className="text-gray-500">Register as a provider to view {pageName}</p>
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}

--- a/user-interfaces/provider/src/lib/chain-client.ts
+++ b/user-interfaces/provider/src/lib/chain-client.ts
@@ -71,18 +71,6 @@ export async function connectToChain(endpoint: string): Promise<PolkadotClient> 
     clearTimeout(timeoutId)
     console.log('@polkadot/api connected to', endpoint)
 
-    // Subscribe to best blocks
-    client.bestBlocks$.subscribe({
-      next: (blocks) => {
-        if (blocks.length > 0) {
-          blockNumber$.next(blocks[0]!.number)
-        }
-      },
-      error: (err) => {
-        console.error('Block subscription error:', err)
-      },
-    })
-
     clientReady$.next(true)
     return client
   } catch (error) {
@@ -135,15 +123,20 @@ export function getUnsafeApi(): any {
 // Signer Helpers for @polkadot/api
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Known dev account URIs
-const DEV_ACCOUNT_URIS: Record<string, string> = {
-  '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY': '//Alice',
-  '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty': '//Bob',
-  '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y': '//Charlie',
-  '5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy': '//Dave',
-  '5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw': '//Eve',
-  '5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL': '//Ferdie',
+// Well-known dev accounts: name -> SS58 address
+export const DEV_ACCOUNTS: Record<string, string> = {
+  Alice: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+  Bob: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+  Charlie: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
+  Dave: '5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy',
+  Eve: '5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw',
+  Ferdie: '5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL',
 }
+
+// Reverse map: address -> URI (derived from DEV_ACCOUNTS)
+const DEV_ACCOUNT_URIS: Record<string, string> = Object.fromEntries(
+  Object.entries(DEV_ACCOUNTS).map(([name, addr]) => [addr, `//${name}`])
+)
 
 /**
  * Get a KeyringPair for dev accounts, or create a custom signer for extension accounts
@@ -404,59 +397,48 @@ export async function isProviderRegistered(address: string): Promise<boolean> {
 }
 
 /**
- * Get provider info from chain
+ * Get provider info and settings from chain in a single query.
+ * Both are stored in the same Providers storage entry.
  */
-export async function getProviderInfo(address: string): Promise<OnChainProviderInfo | null> {
+export async function getProviderData(
+  address: string
+): Promise<{ info: OnChainProviderInfo; settings: OnChainProviderSettings } | null> {
   if (!client || !unsafeApi) throw new Error('Not connected to chain')
 
   try {
     const provider = await unsafeApi.query.StorageProvider.Providers.getValue(address)
     if (!provider) return null
 
-    console.log('Provider info:', provider)
+    console.log('Provider data:', provider)
 
-    return {
+    const info: OnChainProviderInfo = {
       stake: BigInt(provider.stake?.toString() || '0'),
       capacity: provider.capacity ? BigInt(provider.capacity.toString()) : undefined,
       usedCapacity: provider.used_capacity ? BigInt(provider.used_capacity.toString()) : undefined,
       activeBuckets: provider.active_buckets || 0,
       registeredAt: provider.registered_at || 0,
     }
+
+    const settings: OnChainProviderSettings | null = provider.settings
+      ? {
+          minDuration: provider.settings.min_duration || 0,
+          maxDuration: provider.settings.max_duration || 0,
+          pricePerByte: BigInt(provider.settings.price_per_byte?.toString() || '0'),
+          acceptingPrimary: provider.settings.accepting_primary ?? false,
+          acceptingReplica: provider.settings.accepting_replica ?? false,
+          replicaSyncPrice: provider.settings.replica_sync_price
+            ? BigInt(provider.settings.replica_sync_price.toString())
+            : null,
+          acceptingExtensions: provider.settings.accepting_extensions ?? false,
+          maxCapacity: BigInt(provider.settings.max_capacity?.toString() || '0'),
+        }
+      : null
+
+    if (!settings) return null
+
+    return { info, settings }
   } catch (error) {
-    console.error('Error fetching provider info:', error)
-    return null
-  }
-}
-
-/**
- * Get provider settings from chain
- * Settings are embedded in ProviderInfo, not a separate storage item
- */
-export async function getProviderSettings(address: string): Promise<OnChainProviderSettings | null> {
-  if (!client || !unsafeApi) throw new Error('Not connected to chain')
-
-  try {
-    // Settings are part of ProviderInfo in the Providers storage map
-    const provider = await unsafeApi.query.StorageProvider.Providers.getValue(address)
-    if (!provider || !provider.settings) return null
-
-    const settings = provider.settings
-    console.log('Provider settings:', settings)
-
-    return {
-      minDuration: settings.min_duration || 0,
-      maxDuration: settings.max_duration || 0,
-      pricePerByte: BigInt(settings.price_per_byte?.toString() || '0'),
-      acceptingPrimary: settings.accepting_primary ?? false,
-      acceptingReplica: settings.accepting_replica ?? false,
-      replicaSyncPrice: settings.replica_sync_price
-        ? BigInt(settings.replica_sync_price.toString())
-        : null,
-      acceptingExtensions: settings.accepting_extensions ?? false,
-      maxCapacity: BigInt(settings.max_capacity?.toString() || '0'),
-    }
-  } catch (error) {
-    console.error('Error fetching provider settings:', error)
+    console.error('Error fetching provider data:', error)
     return null
   }
 }

--- a/user-interfaces/provider/src/pages/Agreements.tsx
+++ b/user-interfaces/provider/src/pages/Agreements.tsx
@@ -9,35 +9,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table'
-import { useAgreements, useIsRegistered } from '@/state/provider.state'
-import { useSelectedAccount } from '@/state/wallet.state'
+import { useAgreements } from '@/state/provider.state'
+import { RequireProvider } from '@/components/RequireProvider'
 import { formatAddress, formatBytes, formatTokens, formatBlockNumber } from '@/utils/format'
 
 export function Agreements() {
-  const selectedAccount = useSelectedAccount()
-  const isRegistered = useIsRegistered()
+  return (
+    <RequireProvider icon={FileText} pageName="agreements">
+      <AgreementsContent />
+    </RequireProvider>
+  )
+}
+
+function AgreementsContent() {
   const agreements = useAgreements()
-
-  if (!selectedAccount) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <FileText className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Connect Your Wallet</h2>
-        <p className="text-gray-500">Connect a wallet to view your agreements</p>
-      </div>
-    )
-  }
-
-  if (!isRegistered) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <FileText className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Not Registered</h2>
-        <p className="text-gray-500">Register as a provider to view agreements</p>
-      </div>
-    )
-  }
-
   const activeAgreements = agreements.filter((a) => a.status === 'active')
   const expiredAgreements = agreements.filter((a) => a.status !== 'active')
 

--- a/user-interfaces/provider/src/pages/Challenges.tsx
+++ b/user-interfaces/provider/src/pages/Challenges.tsx
@@ -15,15 +15,22 @@ import {
 import {
   useChallenges,
   usePendingChallenges,
-  useIsRegistered,
   respondToChallenge,
 } from '@/state/provider.state'
 import { useSelectedAccount } from '@/state/wallet.state'
+import { RequireProvider } from '@/components/RequireProvider'
 import { formatAddress, formatBlockNumber } from '@/utils/format'
 
 export function Challenges() {
+  return (
+    <RequireProvider icon={Shield} pageName="challenges">
+      <ChallengesContent />
+    </RequireProvider>
+  )
+}
+
+function ChallengesContent() {
   const selectedAccount = useSelectedAccount()
-  const isRegistered = useIsRegistered()
   const challenges = useChallenges()
   const pendingChallenges = usePendingChallenges()
   const [respondingTo, setRespondingTo] = useState<number | null>(null)
@@ -33,7 +40,6 @@ export function Challenges() {
 
     setRespondingTo(challengeId)
     try {
-      // In a real implementation, this would fetch the proof from the provider node
       const mockProof = new Uint8Array(64)
       await respondToChallenge(challengeId, mockProof, selectedAccount)
     } catch (error) {
@@ -41,26 +47,6 @@ export function Challenges() {
     } finally {
       setRespondingTo(null)
     }
-  }
-
-  if (!selectedAccount) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <Shield className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Connect Your Wallet</h2>
-        <p className="text-gray-500">Connect a wallet to view challenges</p>
-      </div>
-    )
-  }
-
-  if (!isRegistered) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <Shield className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Not Registered</h2>
-        <p className="text-gray-500">Register as a provider to view challenges</p>
-      </div>
-    )
   }
 
   const getStatusIcon = (status: string) => {

--- a/user-interfaces/provider/src/pages/Checkpoints.tsx
+++ b/user-interfaces/provider/src/pages/Checkpoints.tsx
@@ -9,34 +9,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table'
-import { useCheckpoints, useIsRegistered } from '@/state/provider.state'
-import { useSelectedAccount } from '@/state/wallet.state'
+import { useCheckpoints } from '@/state/provider.state'
+import { RequireProvider } from '@/components/RequireProvider'
 import { formatBlockNumber, formatRelativeTime, formatAddress } from '@/utils/format'
 
 export function Checkpoints() {
-  const selectedAccount = useSelectedAccount()
-  const isRegistered = useIsRegistered()
+  return (
+    <RequireProvider icon={CheckCircle} pageName="checkpoints">
+      <CheckpointsContent />
+    </RequireProvider>
+  )
+}
+
+function CheckpointsContent() {
   const checkpoints = useCheckpoints()
-
-  if (!selectedAccount) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <CheckCircle className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Connect Your Wallet</h2>
-        <p className="text-gray-500">Connect a wallet to view checkpoints</p>
-      </div>
-    )
-  }
-
-  if (!isRegistered) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <CheckCircle className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Not Registered</h2>
-        <p className="text-gray-500">Register as a provider to view checkpoints</p>
-      </div>
-    )
-  }
 
   // Group checkpoints by bucket
   const checkpointsByBucket = checkpoints.reduce((acc, cp) => {

--- a/user-interfaces/provider/src/pages/Earnings.tsx
+++ b/user-interfaces/provider/src/pages/Earnings.tsx
@@ -5,40 +5,25 @@ import { Progress } from '@/components/ui/Progress'
 import {
   useEarnings,
   useActiveAgreements,
-  useIsRegistered,
   useProviderInfo,
 } from '@/state/provider.state'
-import { useSelectedAccount } from '@/state/wallet.state'
+import { RequireProvider } from '@/components/RequireProvider'
 import { useBlockNumber } from '@/state/chain.state'
 import { formatTokens, formatBytes, formatBlockNumber } from '@/utils/format'
 
 export function Earnings() {
-  const selectedAccount = useSelectedAccount()
-  const isRegistered = useIsRegistered()
+  return (
+    <RequireProvider icon={Coins} pageName="earnings">
+      <EarningsContent />
+    </RequireProvider>
+  )
+}
+
+function EarningsContent() {
   const earnings = useEarnings()
   const activeAgreements = useActiveAgreements()
   const providerInfo = useProviderInfo()
   const currentBlock = useBlockNumber()
-
-  if (!selectedAccount) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <Coins className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Connect Your Wallet</h2>
-        <p className="text-gray-500">Connect a wallet to view your earnings</p>
-      </div>
-    )
-  }
-
-  if (!isRegistered) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <Coins className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Not Registered</h2>
-        <p className="text-gray-500">Register as a provider to view earnings</p>
-      </div>
-    )
-  }
 
   // Calculate agreement progress for each active agreement
   const agreementProgress = activeAgreements.map((agreement) => {

--- a/user-interfaces/provider/src/pages/Overview.tsx
+++ b/user-interfaces/provider/src/pages/Overview.tsx
@@ -12,10 +12,10 @@ import {
   useEarnings,
   useCapacityUsage,
   useIsProviderLoading,
-  useIsRegistered,
   loadProviderData,
 } from '@/state/provider.state'
 import { useSelectedAccount } from '@/state/wallet.state'
+import { RequireProvider } from '@/components/RequireProvider'
 import { formatBytes, formatTokens, formatDuration } from '@/utils/format'
 
 function StatCard({
@@ -54,14 +54,6 @@ function StatCard({
 
 export function Overview() {
   const selectedAccount = useSelectedAccount()
-  const providerInfo = useProviderInfo()
-  const settings = useProviderSettings()
-  const activeAgreements = useActiveAgreements()
-  const pendingChallenges = usePendingChallenges()
-  const earnings = useEarnings()
-  const capacityUsage = useCapacityUsage()
-  const isLoading = useIsProviderLoading()
-  const isRegistered = useIsRegistered()
 
   useEffect(() => {
     if (selectedAccount?.address) {
@@ -69,38 +61,26 @@ export function Overview() {
     }
   }, [selectedAccount?.address])
 
-  if (!selectedAccount) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <Server className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Connect Your Wallet</h2>
-        <p className="text-gray-500">Connect a wallet to view your provider dashboard</p>
-      </div>
-    )
-  }
+  return (
+    <RequireProvider icon={Server} pageName="your provider dashboard">
+      <OverviewContent />
+    </RequireProvider>
+  )
+}
+
+function OverviewContent() {
+  const providerInfo = useProviderInfo()
+  const settings = useProviderSettings()
+  const activeAgreements = useActiveAgreements()
+  const pendingChallenges = usePendingChallenges()
+  const earnings = useEarnings()
+  const capacityUsage = useCapacityUsage()
+  const isLoading = useIsProviderLoading()
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-16">
         <Spinner size="lg" />
-      </div>
-    )
-  }
-
-  if (!isRegistered) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16">
-        <Server className="h-16 w-16 text-gray-600 mb-4" />
-        <h2 className="text-xl font-semibold text-gray-300 mb-2">Not Registered</h2>
-        <p className="text-gray-500 mb-4">
-          This account is not registered as a storage provider
-        </p>
-        <a
-          href="/registration"
-          className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 transition-colors"
-        >
-          Register as Provider
-        </a>
       </div>
     )
   }

--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -8,8 +8,7 @@
 import { BehaviorSubject, map } from 'rxjs'
 import { bind } from '@react-rxjs/core'
 import {
-  getProviderInfo,
-  getProviderSettings,
+  getProviderData,
   getProviderAgreements,
   getProviderCheckpoints,
   getProviderChallenges,
@@ -135,21 +134,14 @@ export async function loadProviderData(address: string): Promise<void> {
   error$.next(null)
 
   try {
-    // Query provider info and settings in parallel
-    const [chainInfo, chainSettings] = await Promise.all([
-      getProviderInfo(address),
-      getProviderSettings(address),
-    ])
+    // Query provider info and settings in a single RPC call
+    const providerData = await getProviderData(address)
 
-    if (chainInfo) {
-      providerInfo$.next(convertProviderInfo(address, chainInfo))
+    if (providerData) {
+      providerInfo$.next(convertProviderInfo(address, providerData.info))
+      providerSettings$.next(convertProviderSettings(providerData.settings))
     } else {
       providerInfo$.next(null)
-    }
-
-    if (chainSettings) {
-      providerSettings$.next(convertProviderSettings(chainSettings))
-    } else {
       providerSettings$.next(null)
     }
 
@@ -194,7 +186,7 @@ export async function registerProvider(
   stake: bigint,
   multiaddr: string,
   settings: ProviderSettings,
-  signer: any, // InjectedPolkadotAccount
+  signer: import('polkadot-api/pjs-signer').InjectedPolkadotAccount,
   onProgress?: (status: import('@/lib/chain-client').TxStatus) => void
 ): Promise<void> {
   isLoading$.next(true)
@@ -219,7 +211,7 @@ export async function registerProvider(
  */
 export async function updateSettings(
   settings: Partial<ProviderSettings>,
-  signer: any, // InjectedPolkadotAccount
+  signer: import('polkadot-api/pjs-signer').InjectedPolkadotAccount,
   onProgress?: (status: import('@/lib/chain-client').TxStatus) => void
 ): Promise<void> {
   const current = providerSettings$.getValue()
@@ -246,7 +238,10 @@ export async function updateSettings(
 /**
  * Add stake (submits extrinsic via wallet)
  */
-export async function addStake(amount: bigint, signer: any): Promise<void> {
+export async function addStake(
+  amount: bigint,
+  signer: import('polkadot-api/pjs-signer').InjectedPolkadotAccount
+): Promise<void> {
   isLoading$.next(true)
   error$.next(null)
 
@@ -276,7 +271,7 @@ export async function addStake(amount: bigint, signer: any): Promise<void> {
 export async function respondToChallenge(
   challengeId: number,
   proof: Uint8Array,
-  signer: any
+  signer: import('polkadot-api/pjs-signer').InjectedPolkadotAccount
 ): Promise<void> {
   isLoading$.next(true)
   error$.next(null)

--- a/user-interfaces/provider/src/state/wallet.state.ts
+++ b/user-interfaces/provider/src/state/wallet.state.ts
@@ -24,7 +24,7 @@ import {
   mnemonicToEntropy,
 } from '@polkadot-labs/hdkd-helpers'
 import { getPolkadotSigner } from 'polkadot-api/signer'
-import { getAccountBalance, isProviderRegistered } from '@/lib/chain-client'
+import { getAccountBalance, isProviderRegistered, DEV_ACCOUNTS } from '@/lib/chain-client'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -94,14 +94,7 @@ function createDevAccountsWithKnownAddresses(): InjectedPolkadotAccount[] {
     const miniSecret = entropyToMiniSecret(entropy)
     const derive = sr25519CreateDerive(miniSecret)
 
-    const knownAddresses: Record<string, string> = {
-      Alice: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
-      Bob: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
-      Charlie: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
-      Dave: '5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy',
-      Eve: '5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw',
-      Ferdie: '5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL',
-    }
+    const knownAddresses = DEV_ACCOUNTS
 
     return DEV_ACCOUNTS.map(({ name, path }) => {
       const keypair = derive(path)


### PR DESCRIPTION
## Summary
- **S3 Pallet**: Fix double storage reads (`contains_key` + `get` → single `get`), fix same-bucket copy bug
- **S3 Client**: Extract `PALLET_NAME` constant (9 occurrences), extract `submit_and_finalize` helper, remove TOCTOU pre-check, add `tokio::try_join!` for concurrent bucket lookups
- **Chain Client**: Merge duplicate `getProviderInfo`/`getProviderSettings` into single `getProviderData` RPC call, consolidate dev account maps, remove leaked `bestBlocks$` subscription
- **Provider State**: Type `signer` parameters as `InjectedPolkadotAccount` instead of `any`
- **Dashboard Pages**: Extract `RequireProvider` guard component from 5 pages