### PR TITLE
feat: deploy all 3 UIs to GitHub Pages as single site

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,88 @@
+name: Deploy UIs to GitHub Pages
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "user-interfaces/**"
+      - ".github/workflows/deploy-ui.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install shared dependencies
+        working-directory: user-interfaces
+        run: npm install
+
+      - name: Build Console UI
+        working-directory: user-interfaces/console-ui
+        env:
+          GITHUB_PAGES: "true"
+        run: |
+          npm install
+          npx papi generate || true
+          npm run build
+
+      - name: Build Provider Dashboard
+        working-directory: user-interfaces/provider
+        env:
+          GITHUB_PAGES: "true"
+        run: |
+          npm install
+          npm run build
+
+      - name: Build Drive UI
+        working-directory: user-interfaces/drive-ui
+        env:
+          GITHUB_PAGES: "true"
+        run: |
+          npm install
+          npm run build
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          # Landing page at root
+          cp user-interfaces/landing/index.html _site/
+          cp user-interfaces/landing/404.html _site/
+          # Each app in its subpath
+          cp -r user-interfaces/console-ui/dist _site/console
+          cp -r user-interfaces/provider/dist _site/provider
+          cp -r user-interfaces/drive-ui/dist _site/drive
+          # Per-app 404.html for SPA routing within each app
+          cp user-interfaces/console-ui/dist/index.html _site/console/404.html
+          cp user-interfaces/provider/dist/index.html _site/provider/404.html
+          cp user-interfaces/drive-ui/dist/index.html _site/drive/404.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/user-interfaces/console-ui/src/main.tsx
+++ b/user-interfaces/console-ui/src/main.tsx
@@ -4,9 +4,11 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles/index.css";
 
+const basename = import.meta.env.BASE_URL.replace(/\/$/, "") || "/";
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <App />
     </BrowserRouter>
   </StrictMode>

--- a/user-interfaces/console-ui/vite.config.ts
+++ b/user-interfaces/console-ui/vite.config.ts
@@ -3,7 +3,10 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+const base = process.env.GITHUB_PAGES ? "/web3-storage/console/" : "/";
+
 export default defineConfig({
+  base,
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/user-interfaces/drive-ui/src/main.tsx
+++ b/user-interfaces/drive-ui/src/main.tsx
@@ -4,9 +4,11 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles/index.css";
 
+const basename = import.meta.env.BASE_URL.replace(/\/$/, "") || "/";
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <App />
     </BrowserRouter>
   </StrictMode>

--- a/user-interfaces/drive-ui/vite.config.ts
+++ b/user-interfaces/drive-ui/vite.config.ts
@@ -3,7 +3,10 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+const base = process.env.GITHUB_PAGES ? "/web3-storage/drive/" : "/";
+
 export default defineConfig({
+  base,
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/user-interfaces/landing/404.html
+++ b/user-interfaces/landing/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Web3 Storage</title>
+  <script>
+    // SPA redirect for GitHub Pages.
+    // Detects which app the path belongs to and redirects to that app's index.html
+    // with the original path preserved as a query parameter for the client-side router.
+    var path = window.location.pathname;
+    var apps = ['/web3-storage/console/', '/web3-storage/provider/', '/web3-storage/drive/'];
+    var matched = apps.find(function(app) { return path.startsWith(app); });
+    if (matched) {
+      // Redirect to the app's index.html — the SPA router will handle the rest
+      var rest = path.slice(matched.length);
+      window.location.replace(matched + '?p=' + encodeURIComponent('/' + rest) + window.location.search.replace('?', '&') + window.location.hash);
+    } else {
+      window.location.replace('/web3-storage/');
+    }
+  </script>
+</head>
+<body></body>
+</html>

--- a/user-interfaces/landing/index.html
+++ b/user-interfaces/landing/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Web3 Storage</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0f;
+      color: #e5e5e5;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container { max-width: 800px; padding: 2rem; text-align: center; }
+    h1 { font-size: 2.5rem; font-weight: 700; margin-bottom: 0.5rem; }
+    .subtitle { color: #888; font-size: 1.1rem; margin-bottom: 3rem; }
+    .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
+    .card {
+      background: #1a1a2e;
+      border: 1px solid #2a2a3e;
+      border-radius: 12px;
+      padding: 2rem 1.5rem;
+      text-decoration: none;
+      color: inherit;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .card:hover { border-color: #7c3aed; transform: translateY(-2px); }
+    .card h2 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    .card p { color: #888; font-size: 0.9rem; line-height: 1.5; }
+    .icon { font-size: 2rem; margin-bottom: 1rem; }
+    @media (max-width: 600px) { .cards { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Web3 Storage</h1>
+    <p class="subtitle">Decentralized storage with game-theoretic guarantees</p>
+    <div class="cards">
+      <a href="./console/" class="card">
+        <div class="icon">&#x1F4E6;</div>
+        <h2>Storage Console</h2>
+        <p>Create S3 buckets, upload and download objects, manage permissions, and explore blockchain events.</p>
+      </a>
+      <a href="./provider/" class="card">
+        <div class="icon">&#x1F5A5;</div>
+        <h2>Provider Dashboard</h2>
+        <p>Register as a storage provider, manage agreements, respond to challenges, and track earnings.</p>
+      </a>
+      <a href="./drive/" class="card">
+        <div class="icon">&#x1F4C1;</div>
+        <h2>Drive</h2>
+        <p>File manager interface. Create drives, browse directories, upload and download files.</p>
+      </a>
+    </div>
+  </div>
+</body>
+</html>

--- a/user-interfaces/landing/index.html
+++ b/user-interfaces/landing/index.html
@@ -32,6 +32,18 @@
     .card h2 { font-size: 1.25rem; margin-bottom: 0.5rem; }
     .card p { color: #888; font-size: 0.9rem; line-height: 1.5; }
     .icon { font-size: 2rem; margin-bottom: 1rem; }
+    .banner {
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      border: 1px solid #2a2a3e;
+      border-radius: 10px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 2.5rem;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      color: #aaa;
+    }
+    .banner a { color: #a78bfa; text-decoration: none; }
+    .banner a:hover { text-decoration: underline; }
     @media (max-width: 600px) { .cards { grid-template-columns: 1fr; } }
   </style>
 </head>
@@ -39,6 +51,13 @@
   <div class="container">
     <h1>Web3 Storage</h1>
     <p class="subtitle">Decentralized storage with game-theoretic guarantees</p>
+    <div class="banner">
+      Successor to the <a href="https://paritytech.github.io/polkadot-bulletin-chain/">Polkadot Bulletin Chain</a> storage system.
+      Rather than heavy cryptographic proofs on every operation, Web3 Storage uses economic incentives:
+      providers lock stake proportional to their capacity and face slashing for data loss.
+      The chain acts as a credible threat for accountability, not the hot path &mdash;
+      normal reads and writes happen off-chain via HTTP and scale with provider capacity, not chain throughput.
+    </div>
     <div class="cards">
       <a href="./console/" class="card">
         <div class="icon">&#x1F4E6;</div>

--- a/user-interfaces/provider/src/main.tsx
+++ b/user-interfaces/provider/src/main.tsx
@@ -21,7 +21,7 @@ function AppWithInit() {
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Subscribe fallback={<div className="min-h-screen bg-gray-950" />}>
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
         <AppWithInit />
       </BrowserRouter>
     </Subscribe>

--- a/user-interfaces/provider/vite.config.ts
+++ b/user-interfaces/provider/vite.config.ts
@@ -3,7 +3,10 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
+const base = process.env.GITHUB_PAGES ? '/web3-storage/provider/' : '/'
+
 export default defineConfig({
+  base,
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
# Description

Build console-ui, provider dashboard, and drive-ui into subpaths under paritytech.github.io/web3-storage/:
  * /web3-storage/          → landing page
  * /web3-storage/console/  → S3 storage console
  * /web3-storage/provider/ → provider dashboard
  * /web3-storage/drive/    → file manager

Each app gets a conditional base path (GITHUB_PAGES env) and BrowserRouter basename from import.meta.env.BASE_URL. Landing page links to all three. 404.html handles SPA routing by detecting the subpath and redirecting to the correct app.

Closes #49.