### PR TITLE
ci: add Parity /cmd bot for bench & fmt

### DIFF
--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -1,0 +1,417 @@
+name: Command - Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      cmd:
+        description: "Command to run"
+        required: true
+      pr_num:
+        description: "PR number"
+        required: true
+      pr_branch:
+        description: "PR branch"
+        required: true
+      runner:
+        description: "Runner to use"
+        required: true
+      image:
+        description: "Image to use"
+        required: true
+      is_org_member:
+        description: "Is the user an org member"
+        required: true
+      is_pr_author:
+        description: "Is the user the PR author"
+        required: true
+      repo:
+        description: "Repository to use"
+        required: true
+      comment_id:
+        description: "Comment ID"
+        required: true
+      is_quiet:
+        description: "Quiet mode"
+        required: false
+        default: "false"
+
+permissions: # allow the action to comment on the PR
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  before-cmd:
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAME: "cmd"
+      CMD: ${{ github.event.inputs.cmd }}
+      PR_BRANCH: ${{ github.event.inputs.pr_branch }}
+      PR_NUM: ${{ github.event.inputs.pr_num }}
+    outputs:
+      job_url: ${{ steps.build-link.outputs.job_url }}
+      run_url: ${{ steps.build-link.outputs.run_url }}
+    steps:
+      - name: Build workflow link
+        if: ${{ github.event.inputs.is_quiet == 'false' }}
+        id: build-link
+        run: |
+          # Get exactly the CMD job link, filtering out the other jobs
+          jobLink=$(curl -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[] | select(.name | contains("${{ env.JOB_NAME }}")) | .html_url')
+
+          runLink=$(curl -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq '.html_url')
+
+          echo "job_url=${jobLink}"
+          echo "run_url=${runLink}"
+          echo "job_url=$jobLink" >> $GITHUB_OUTPUT
+          echo "run_url=$runLink" >> $GITHUB_OUTPUT
+
+      - name: Comment PR (Start)
+        # No need to comment if --quiet
+        if: ${{ github.event.inputs.is_quiet == 'false' && !startsWith(github.event.inputs.cmd, 'fmt') }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let job_url = ${{ steps.build-link.outputs.job_url }}
+            let cmd = process.env.CMD;
+            github.rest.issues.createComment({
+              issue_number: ${{ env.PR_NUM }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Command "${cmd}" has started 🚀 [See logs here](${job_url})`
+            })
+
+      - name: Debug info
+        env:
+          CMD: ${{ github.event.inputs.cmd }}
+          PR_BRANCH: ${{ github.event.inputs.pr_branch }}
+          PR_NUM: ${{ github.event.inputs.pr_num }}
+          RUNNER: ${{ github.event.inputs.runner }}
+          IMAGE: ${{ github.event.inputs.image }}
+          IS_ORG_MEMBER: ${{ github.event.inputs.is_org_member }}
+          REPO: ${{ github.event.inputs.repo }}
+          COMMENT_ID: ${{ github.event.inputs.comment_id }}
+          IS_QUIET: ${{ github.event.inputs.is_quiet }}
+        run: |
+          echo "Running command: $CMD"
+          echo "PR number: $PR_NUM"
+          echo "PR branch: $PR_BRANCH"
+          echo "Runner: $RUNNER"
+          echo "Image: $IMAGE"
+          echo "Is org member: $IS_ORG_MEMBER"
+          echo "Repository: $REPO"
+          echo "Comment ID: $COMMENT_ID"
+          echo "Is quiet: $IS_QUIET"
+
+  cmd:
+    needs: [before-cmd]
+    env:
+      CMD: ${{ github.event.inputs.cmd }}
+      PR_BRANCH: ${{ github.event.inputs.pr_branch }}
+      PR_NUM: ${{ github.event.inputs.pr_num }}
+      REPO: ${{ github.event.inputs.repo }}
+    runs-on: ${{ github.event.inputs.runner }}
+    container:
+      image: ${{ github.event.inputs.image }}
+    timeout-minutes: 1440 # 24 hours per runtime
+    # lowerdown permissions to separate permissions context for executable parts by contributors
+    permissions:
+      contents: read
+      pull-requests: none
+      actions: none
+      issues: none
+    outputs:
+      cmd_output: ${{ steps.cmd.outputs.cmd_output }}
+      subweight: ${{ steps.subweight.outputs.result }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ env.REPO }}
+          ref: ${{ env.PR_BRANCH }}
+
+      - name: Run cmd
+        id: cmd
+        env:
+          IS_ORG_MEMBER: ${{ github.event.inputs.is_org_member }}
+          IS_PR_AUTHOR: ${{ github.event.inputs.is_pr_author }}
+          RUNNER: ${{ github.event.inputs.runner }}
+          IMAGE: ${{ github.event.inputs.image }}
+        run: |
+          echo "Running command: "${CMD}" on "${RUNNER}" runner, container: "${IMAGE}
+          echo "IS_ORG_MEMBER: ${IS_ORG_MEMBER}"
+
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config user.name "cmd[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          echo "Using dev branch for cmd-bot scripts"
+          TMP_DIR=/tmp/web3-storage
+          git clone --depth 1 --branch dev https://github.com/paritytech/web3-storage $TMP_DIR
+          BOT_PATH=$TMP_DIR
+
+          python3 $BOT_PATH/scripts/cmd/cmd.py $CMD
+          git status > /tmp/cmd/git_status.log
+          git diff > /tmp/cmd/git_diff.log
+
+          if [ -f /tmp/cmd/command_output.log ]; then
+            CMD_OUTPUT=$(cat /tmp/cmd/command_output.log)
+            # export to summary to display in the PR
+            echo "$CMD_OUTPUT" >> $GITHUB_STEP_SUMMARY
+            # should be multiline, otherwise it captures the first line only
+            echo 'cmd_output<<EOF' >> $GITHUB_OUTPUT
+            echo "$CMD_OUTPUT" >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          fi
+
+          git add -A
+          git diff HEAD > /tmp/cmd/command_diff.patch -U0
+          git commit -m "tmp cmd: $CMD" || true
+          # without push, as we're saving the diff to an artifact and subweight will compare the local branch with the remote branch
+
+      - name: Upload command output
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: command-output
+          path: /tmp/cmd/command_output.log
+
+      - name: Upload command diff
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: command-diff
+          path: /tmp/cmd/command_diff.patch
+
+      - name: Upload git status
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: git-status
+          path: /tmp/cmd/git_status.log
+
+      - name: Upload git diff
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: git-diff
+          path: /tmp/cmd/git_diff.log
+
+      - name: Install subweight for bench
+        if: startsWith(github.event.inputs.cmd, 'bench')
+        run: cargo install subweight
+
+      - name: Run Subweight for bench
+        id: subweight
+        if: startsWith(github.event.inputs.cmd, 'bench')
+        shell: bash
+        run: |
+          git fetch
+          git remote -v
+          echo $(git log -n 2 --oneline)
+
+          result=$(subweight compare commits \
+            --path-pattern "./**/weights/**/*.rs,./**/weights.rs" \
+            --method asymptotic \
+            --format markdown \
+            --no-color \
+            --change added changed \
+            --ignore-errors \
+            refs/remotes/origin/dev $PR_BRANCH)
+
+          echo $result
+
+          echo $result > /tmp/cmd/subweight.log
+          # Check if /tmp/cmd/subweight.log is more than 1048576 bytes
+          if [ $(wc -c < "/tmp/cmd/subweight.log") -gt 1048576 ]; then
+            echo "Subweight result is too large, truncating..."
+            result=$(echo "$result" | head -c 100000)
+          fi
+
+          echo $result
+
+          echo $result > /tmp/cmd/subweight.log
+          # Though github claims that it supports 1048576 bytes in GITHUB_OUTPUT in fact it only supports ~200000 bytes of a multiline string
+          if [ $(wc -c < "/tmp/cmd/subweight.log") -gt 200000 ]; then
+            echo "Subweight result is too large, truncating..."
+            echo "Please check subweight.log for the full output"
+            result="Please check subweight.log for the full output"
+          fi
+          echo "Trying to save subweight result to GITHUB_OUTPUT"
+          # Save the multiline result to the output
+          {
+            echo "result<<EOF"
+            echo "$result"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Upload Subweight
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: startsWith(github.event.inputs.cmd, 'bench')
+        with:
+          name: subweight
+          path: /tmp/cmd/subweight.log
+
+  after-cmd:
+    needs: [cmd, before-cmd]
+    env:
+      CMD: ${{ github.event.inputs.cmd }}
+      PR_BRANCH: ${{ github.event.inputs.pr_branch }}
+      PR_NUM: ${{ github.event.inputs.pr_num }}
+      REPO: ${{ github.event.inputs.repo }}
+    runs-on: ubuntu-latest
+    steps:
+      # needs to be able to trigger CI, as default token does not retrigger
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate_token
+        with:
+          app-id: ${{ secrets.CMD_BOT_APP_ID }}
+          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          repository: ${{ env.REPO }}
+          ref: ${{ env.PR_BRANCH }}
+
+      - name: Download command-diff artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: command-diff
+          path: command-diff
+
+      - name: Apply & Commit changes
+        run: |
+          ls -lsa .
+
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config user.name "cmd[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global pull.rebase false
+
+          echo "Applying $file"
+          git apply "command-diff/command_diff.patch" --unidiff-zero --allow-empty
+
+          rm -rf command-diff
+
+          git status
+
+          if [ -n "$(git status --porcelain)" ]; then
+
+            git remote -v
+
+            push_changes() {
+              git push origin "HEAD:$PR_BRANCH"
+            }
+
+            git add .
+            git restore --staged Cargo.lock # ignore changes in Cargo.lock
+            git commit -m "Update from ${{ github.actor }} running command '$CMD'" || true
+
+            # Attempt to push changes
+            if ! push_changes; then
+              echo "Push failed, trying to rebase..."
+              git pull --rebase origin $PR_BRANCH
+              # After successful rebase, try pushing again
+              push_changes
+            fi
+          else
+            echo "Nothing to commit";
+          fi
+
+
+      - name: Comment PR (End)
+        # No need to comment if --quiet
+        if: ${{ github.event.inputs.is_quiet == 'false' && needs.cmd.result == 'success' && !startsWith(github.event.inputs.cmd, 'fmt') }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SUBWEIGHT: "${{ needs.cmd.outputs.subweight }}"
+          CMD_OUTPUT: "${{ needs.cmd.outputs.cmd_output }}"
+          PR_NUM: ${{ github.event.inputs.pr_num }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let runUrl = ${{ needs.before-cmd.outputs.run_url }};
+            let subweight = process.env.SUBWEIGHT || '';
+            let cmdOutput = process.env.CMD_OUTPUT || '';
+            let cmd = process.env.CMD;
+            console.log(cmdOutput);
+
+            let subweightCollapsed = subweight.trim() !== ''
+              ? `<details>\n\n<summary>Subweight results:</summary>\n\n${subweight}\n\n</details>`
+              : '';
+
+            let cmdOutputCollapsed = cmdOutput.trim() !== ''
+              ? `<details>\n\n<summary>Command output:</summary>\n\n${cmdOutput}\n\n</details>`
+              : '';
+
+            github.rest.issues.createComment({
+              issue_number: ${{ env.PR_NUM }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Command "${cmd}" has finished ✅ [See logs here](${runUrl})${subweightCollapsed}${cmdOutputCollapsed}`
+            })
+
+
+  finish:
+    needs: [before-cmd, cmd, after-cmd]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      CMD_OUTPUT: "${{ needs.cmd.outputs.cmd_output }}"
+      CMD: ${{ github.event.inputs.cmd }}
+      PR_NUM: ${{ github.event.inputs.pr_num }}
+      COMMENT_ID: ${{ github.event.inputs.comment_id }}
+    steps:
+      - name: Comment PR (Failure)
+        if: ${{ needs.cmd.result == 'failure' || needs.after-cmd.result == 'failure' || needs.before-cmd.result == 'failure' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let jobUrl = ${{ needs.before-cmd.outputs.job_url }};
+            let cmdOutput = process.env.CMD_OUTPUT;
+            let cmd = process.env.CMD;
+            let cmdOutputCollapsed = '';
+            if (cmdOutput && cmdOutput.trim() !== '') {
+              cmdOutputCollapsed = `<details>\n\n<summary>Command output:</summary>\n\n${cmdOutput}\n\n</details>`
+            }
+
+            github.rest.issues.createComment({
+              issue_number: ${{ env.PR_NUM }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Command "${cmd}" has failed ❌! [See logs here](${jobUrl})${cmdOutputCollapsed}`
+            })
+
+      - name: Add 😕 reaction on failure
+        if: ${{ needs.cmd.result == 'failure' || needs.after-cmd.result == 'failure' || needs.before-cmd.result == 'failure' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              comment_id: ${{ env.COMMENT_ID }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              content: 'confused'
+            })
+
+      - name: Add 👍 reaction on success
+        if: ${{ needs.cmd.result == 'success' && needs.after-cmd.result == 'success' && needs.before-cmd.result == 'success' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              comment_id: ${{ env.COMMENT_ID }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              content: '+1'
+            })

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -1,0 +1,341 @@
+name: Command
+
+on:
+  issue_comment: # listen for comments on issues
+    types: [created]
+
+permissions: # allow the action to comment in PR
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  is-org-member:
+    if: startsWith(github.event.comment.body, '/cmd')
+    runs-on: ubuntu-latest
+    outputs:
+      member: ${{ steps.is-member.outputs.result }}
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CMD_BOT_APP_ID }}
+          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
+
+      - name: Check if user is a member of the organization
+        id: is-member
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          result-encoding: string
+          script: |
+            const fs = require("fs");
+            try {
+              const org = '${{ github.event.repository.owner.login }}';
+              const username = '${{ github.event.comment.user.login }}';
+
+              const membership = await github.rest.orgs.checkMembershipForUser({
+                  org: org,
+                  username: username
+              });
+
+              console.log(membership, membership.status, membership.status === 204);
+
+              if (membership.status === 204) {
+                return 'true';
+              } else {
+                console.log(membership);
+                fs.appendFileSync(process.env["GITHUB_STEP_SUMMARY"], `${membership.data && membership.data.message || 'Unknown error happened, please check logs'}`);
+              }
+            } catch (error) {
+              console.log(error)
+            }
+
+            return 'false';
+
+  acknowledge:
+    if: ${{ startsWith(github.event.comment.body, '/cmd') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reaction to triggered comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              comment_id: ${{ github.event.comment.id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              content: 'eyes'
+            })
+
+  clean:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean previous comments
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: ${{ startsWith(github.event.comment.body, '/cmd') && contains(github.event.comment.body, '--clean') }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            }).then(comments => {
+              for (let comment of comments.data) {
+                console.log(comment)
+                if (
+                  ${{ github.event.comment.id }} !== comment.id &&
+                    (
+                      (
+                        (
+                          comment.body.startsWith('Command') ||
+                          comment.body.startsWith('<details><summary>Command') ||
+                          comment.body.startsWith('Sorry, only ')
+                        ) && comment.user.type === 'Bot'
+                      ) ||
+                      (comment.body.startsWith('/cmd') && comment.user.login === context.actor)
+                    )
+                ) {
+                  github.rest.issues.deleteComment({
+                    comment_id: comment.id,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo
+                  })
+                }
+              }
+            })
+
+  get-pr-info:
+    if: ${{ startsWith(github.event.comment.body, '/cmd') }}
+    runs-on: ubuntu-latest
+    outputs:
+      CMD: ${{ steps.get-comment.outputs.group2 }}
+      pr-branch: ${{ steps.get-pr.outputs.pr_branch }}
+      repo: ${{ steps.get-pr.outputs.repo }}
+    steps:
+      - name: Get command
+        uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
+        id: get-comment
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: "^(\\/cmd )([-\\/\\s\\w.=:]+)$" # see explanation in docs/contributor/commands-readme.md#examples
+
+      # Get PR branch name, because the issue_comment event does not contain the PR branch name
+      - name: Check if the issue is a PR
+        id: check-pr
+        run: |
+          if [ -n "${{ github.event.issue.pull_request.url }}" ]; then
+            echo "This is a pull request comment"
+          else
+            echo "This is not a pull request comment"
+            exit 1
+          fi
+
+      - name: Get PR Branch Name and Repo
+        if: steps.check-pr.outcome == 'success'
+        id: get-pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const prBranch = pr.data.head.ref;
+            const repo = pr.data.head.repo.full_name;
+            console.log(prBranch, repo)
+            core.setOutput('pr_branch', prBranch);
+            core.setOutput('repo', repo);
+
+      - name: Use PR Branch Name and Repo
+        env:
+          PR_BRANCH: ${{ steps.get-pr.outputs.pr_branch }}
+          REPO: ${{ steps.get-pr.outputs.repo }}
+          CMD: ${{ steps.get-comment.outputs.group2 }}
+        run: |
+          echo "The PR branch is $PR_BRANCH"
+          echo "The repository is $REPO"
+          echo "The CMD is $CMD"
+
+  help:
+    needs: [clean, get-pr-info]
+    if: ${{ startsWith(github.event.comment.body, '/cmd') && contains(github.event.comment.body, '--help') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Save output of help
+        id: help
+        env:
+          CMD: ${{ needs.get-pr-info.outputs.CMD }} # to avoid "" around the command
+        run: |
+          echo 'help<<EOF' >> $GITHUB_OUTPUT
+          python3 scripts/cmd/cmd.py $CMD >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: Comment PR (Help)
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `<details><summary>Command help:</summary>
+
+            \`\`\`
+            ${{ steps.help.outputs.help }}
+            \`\`\`
+
+            </details>`
+            })
+
+      - name: Add confused reaction on failure
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: ${{ failure() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              comment_id: ${{ github.event.comment.id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              content: 'confused'
+            })
+
+      - name: Add 👍 reaction on success
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: ${{ !failure() }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              comment_id: ${{ github.event.comment.id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              content: '+1'
+            })
+
+  set-image:
+    needs: [clean, get-pr-info]
+    if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(github.event.comment.body, '--help') }}
+    uses: ./.github/workflows/set-image.yml
+
+  set-runner:
+    needs: [get-pr-info, set-image]
+    if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(github.event.comment.body, '--help') }}
+    runs-on: ubuntu-latest
+    env:
+      CMD: ${{ needs.get-pr-info.outputs.CMD }}
+      DEFAULT_IMAGE: ${{ needs.set-image.outputs.CI_IMAGE }}
+    outputs:
+      IMAGE: ${{ steps.set-image.outputs.IMAGE }}
+      RUNNER: ${{ steps.set-image.outputs.RUNNER }}
+    steps:
+      - id: set-image
+        run: |
+          BODY=$(echo "$CMD" | xargs) # remove whitespace
+          IMAGE_OVERRIDE=$(echo "$BODY" | grep -oe 'docker.io/paritytech/ci-unified:[^[:space:]]*' || true)
+
+          if [ -n "$IMAGE_OVERRIDE" ]; then
+              echo "IMAGE=$IMAGE_OVERRIDE" >> $GITHUB_OUTPUT
+          else
+              echo "IMAGE=$DEFAULT_IMAGE" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ $BODY == "bench"* ]]; then
+              echo "RUNNER=parity-weights" >> $GITHUB_OUTPUT
+          elif [[ $BODY == "update-ui"* ]]; then
+              echo "RUNNER=parity-large" >> $GITHUB_OUTPUT
+          else
+              echo "RUNNER=ubuntu-latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Print outputs
+        run: |
+          echo "RUNNER=${{ steps.set-image.outputs.RUNNER }}"
+          echo "IMAGE=${{ steps.set-image.outputs.IMAGE }}"
+
+  check-pr-author:
+    runs-on: ubuntu-latest
+    outputs:
+      is_author: ${{ steps.check-author.outputs.result }}
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CMD_BOT_APP_ID }}
+          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
+
+      - name: Check if user is PR author
+        id: check-author
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          result-encoding: string
+          script: |
+            const commentUser = '${{ github.event.comment.user.login }}';
+            const prNumber = ${{ github.event.issue.number }};
+
+            try {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+
+              const prAuthor = pr.data.user.login;
+              return commentUser === prAuthor ? 'true' : 'false';
+            } catch (error) {
+              console.error('Error checking PR author:', error);
+              return 'false';
+            }
+
+  run-cmd-workflow:
+    needs: [set-runner, get-pr-info, is-org-member, check-pr-author]
+    runs-on: ubuntu-latest
+    # don't run on help; require commenter to be an org member or the PR author
+    if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(github.event.comment.body, '--help') && (needs.is-org-member.outputs.member == 'true' || needs.check-pr-author.outputs.is_author == 'true') }}
+    permissions: # run workflow
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: write
+    env:
+      CMD: ${{ needs.get-pr-info.outputs.CMD }}
+      PR_BRANCH: ${{ needs.get-pr-info.outputs.pr-branch }}
+      RUNNER: ${{ needs.set-runner.outputs.RUNNER }}
+      IMAGE: ${{ needs.set-runner.outputs.IMAGE }}
+      REPO: ${{ needs.get-pr-info.outputs.repo }}
+      IS_ORG_MEMBER: ${{ needs.is-org-member.outputs.member }}
+      IS_PR_AUTHOR: ${{ needs.check-pr-author.outputs.is_author }}
+      COMMENT_ID: ${{ github.event.comment.id }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Start cmd with gh cli
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run cmd-run.yml \
+            --ref dev \
+            -f cmd="${CMD}" \
+            -f repo="${REPO}" \
+            -f pr_branch="${PR_BRANCH}" \
+            -f pr_num="${PR_NUMBER}" \
+            -f runner="${RUNNER}" \
+            -f is_org_member="${IS_ORG_MEMBER}" \
+            -f is_pr_author="${IS_PR_AUTHOR}" \
+            -f comment_id="${COMMENT_ID}" \
+            -f image="${IMAGE}" \
+            -f is_quiet="${{ contains(github.event.comment.body, '--quiet') }}"

--- a/scripts/cmd/cmd.py
+++ b/scripts/cmd/cmd.py
@@ -9,6 +9,20 @@ import _help
 
 _HelpAction = _help._HelpAction
 
+
+def print_and_log(message, output_file='/tmp/cmd/command_output.log'):
+    print(message)
+    with open(output_file, 'a') as f:
+        f.write(message + '\n')
+
+
+def setup_logging():
+    if not os.path.exists('/tmp/cmd'):
+        os.makedirs('/tmp/cmd')
+    open('/tmp/cmd/command_output.log', 'w').close()
+
+setup_logging()
+
 f = open('scripts/runtimes-matrix.json', 'r')
 runtimesMatrix = json.load(f)
 
@@ -73,35 +87,35 @@ for arg, config in common_args.items():
 
 args, unknown = parser.parse_known_args()
 
-print(f'args: {args}')
+print_and_log(f'args: {args}')
 
 if args.command == 'bench':
     tempdir = tempfile.TemporaryDirectory()
-    print(f'Created temp dir: {tempdir.name}')
+    print_and_log(f'Created temp dir: {tempdir.name}')
     runtime_pallets_map = {}
     failed_benchmarks = {}
     successful_benchmarks = {}
 
     profile = args.profile
 
-    print(f'Provided runtimes: {args.runtime}')
-    print(f'Cargo profile: {profile}')
+    print_and_log(f'Provided runtimes: {args.runtime}')
+    print_and_log(f'Cargo profile: {profile}')
     # convert to mapped dict
     runtimesMatrix = list(filter(lambda x: x['name'] in args.runtime, runtimesMatrix))
     runtimesMatrix = {x['name']: x for x in runtimesMatrix}
-    print(f'Filtered out runtimes: {runtimesMatrix}')
+    print_and_log(f'Filtered out runtimes: {runtimesMatrix}')
 
     # loop over remaining runtimes to collect available pallets
     for runtime in runtimesMatrix.values():
-        print(f'-- compiling the runtime {runtime["name"]}')
+        print_and_log(f'-- compiling the runtime {runtime["name"]}')
         os.system(f"cargo build -p {runtime['package']} --profile {profile} --features runtime-benchmarks")
-        print(f'-- listing pallets for benchmark for {runtime["name"]}')
+        print_and_log(f'-- listing pallets for benchmark for {runtime["name"]}')
         wasm_file = f"target/{profile}/wbuild/{runtime['package']}/{runtime['package'].replace('-', '_')}.wasm"
-        print(f"frame-omni-bencher v1 benchmark pallet --no-csv-header --all --list --runtime={wasm_file}")
+        print_and_log(f"frame-omni-bencher v1 benchmark pallet --no-csv-header --all --list --runtime={wasm_file}")
         output = os.popen(
             f"frame-omni-bencher v1 benchmark pallet --no-csv-header --all --list --runtime={wasm_file}").read()
         if output == "":
-            print(f'frame-omni-bencher not found')
+            print_and_log(f'frame-omni-bencher not found')
             sys.exit(1)
         raw_pallets = output.split('\n')
 
@@ -111,12 +125,12 @@ if args.command == 'bench':
                 all_pallets.add(pallet.split(',')[0].strip())
 
         pallets = list(all_pallets)
-        print(f'Pallets in {runtime}: {pallets}')
+        print_and_log(f'Pallets in {runtime}: {pallets}')
         runtime_pallets_map[runtime['name']] = pallets
 
     # filter out only the specified pallets from collected runtimes/pallets
     if args.pallet:
-        print(f'Pallet: {args.pallet}')
+        print_and_log(f'Pallet: {args.pallet}')
         new_pallets_map = {}
         # keep only specified pallets if they exist in the runtime
         for runtime in runtime_pallets_map:
@@ -125,17 +139,17 @@ if args.command == 'bench':
 
         runtime_pallets_map = new_pallets_map
 
-    print(f'Filtered out runtimes & pallets: {runtime_pallets_map}')
+    print_and_log(f'Filtered out runtimes & pallets: {runtime_pallets_map}')
 
     if not runtime_pallets_map:
         if args.pallet and not args.runtime:
-            print(f"No pallets [{args.pallet}] found in any runtime")
+            print_and_log(f"No pallets [{args.pallet}] found in any runtime")
         elif args.runtime and not args.pallet:
-            print(f"{args.runtime} runtime does not have any pallets")
+            print_and_log(f"{args.runtime} runtime does not have any pallets")
         elif args.runtime and args.pallet:
-            print(f"No pallets [{args.pallet}] found in {args.runtime}")
+            print_and_log(f"No pallets [{args.pallet}] found in {args.runtime}")
         else:
-            print('No runtimes found')
+            print_and_log('No runtimes found')
         sys.exit(1)
 
     header_path = os.path.abspath('./scripts/cmd/file_header.txt')
@@ -143,7 +157,7 @@ if args.command == 'bench':
     for runtime in runtime_pallets_map:
         for pallet in runtime_pallets_map[runtime]:
             config = runtimesMatrix[runtime]
-            print(f'-- config: {config}')
+            print_and_log(f'-- config: {config}')
             default_path = f"./{config['path']}/src/weights"
             xcm_path = f"./{config['path']}/src/weights/xcm"
             output_path = default_path if not pallet.startswith("pallet_xcm_benchmarks") else xcm_path
@@ -153,7 +167,7 @@ if args.command == 'bench':
             excluded = excluded_extrinsics.get(pallet, [])
             excluded_string = ",".join(f"{pallet}::{e}" for e in excluded)
 
-            print(f'-- benchmarking {pallet} in {runtime} into {output_path} using template {template}')
+            print_and_log(f'-- benchmarking {pallet} in {runtime} into {output_path} using template {template}')
 
             status = os.system(f"frame-omni-bencher v1 benchmark pallet "
                                f"--extrinsic=* "
@@ -170,7 +184,7 @@ if args.command == 'bench':
                                f"{f'--exclude-extrinsics={excluded_string} ' if excluded_string else ''}"
                                )
             if status != 0 and not args.continue_on_fail:
-                print(f'Failed to benchmark {pallet} in {runtime}')
+                print_and_log(f'Failed to benchmark {pallet} in {runtime}')
                 sys.exit(1)
 
             # Otherwise collect failed benchmarks and print them at the end
@@ -181,26 +195,25 @@ if args.command == 'bench':
                 successful_benchmarks[f'{runtime}'] = successful_benchmarks.get(f'{runtime}', []) + [pallet]
 
     if failed_benchmarks:
-        print('❌ Failed benchmarks of runtimes/pallets:')
+        print_and_log('❌ Failed benchmarks of runtimes/pallets:')
         for runtime, pallets in failed_benchmarks.items():
-            print(f'-- {runtime}: {pallets}')
+            print_and_log(f'-- {runtime}: {pallets}')
 
     if successful_benchmarks:
-        print('✅ Successful benchmarks of runtimes/pallets:')
+        print_and_log('✅ Successful benchmarks of runtimes/pallets:')
         for runtime, pallets in successful_benchmarks.items():
-            print(f'-- {runtime}: {pallets}')
+            print_and_log(f'-- {runtime}: {pallets}')
 
     tempdir.cleanup()
 
 elif args.command == 'fmt':
-    nightly_version = os.getenv('RUST_NIGHTLY_VERSION')
-    command = f"cargo +nightly-{nightly_version} fmt"
-    print('Formatting with `{command}`')
-    nightly_status = os.system(f'{command}')
+    command = "cargo +nightly fmt"
+    print_and_log(f'Formatting with `{command}`...')
+    nightly_status = os.system(command)
     taplo_status = os.system('taplo format --config .config/taplo.toml')
 
     if (nightly_status != 0 or taplo_status != 0) and not args.continue_on_fail:
-        print('❌ Failed to format code')
+        print_and_log('❌ Failed to format code')
         sys.exit(1)
 
-print('🚀 Done')
+print_and_log('🚀 Done')


### PR DESCRIPTION
## Summary

  Ports the Parity /cmd bot from [paritytech/polkadot-bulletin-chain#464](https://github.com/paritytech/polkadot-bulletin-chain/pull/464). Once merged, reviewers can comment /cmd bench … or /cmd fmt on a PR; the bot runs the command in CI and pushes the resulting diff back to the PR branch. Authorization passes if the commenter
   is either a paritytech org member or the PR author.

  The supporting plumbing (scripts/cmd/cmd.py, scripts/runtimes-matrix.json, .github/workflows/set-image.yml) was already in the repo from an earlier pass — this PR adds the two missing workflow files and a small cmd.py upgrade so PR comments can echo command
  output.

## Changes

  - .github/workflows/cmd.yml — listens for issue_comment.created on PRs whose body starts with /cmd; resolves auth, parses the comment, picks an image + runner, dispatches cmd-run.yml. Verbatim port aside from --ref dev (this repo's default branch).
  - .github/workflows/cmd-run.yml — before-cmd → cmd → after-cmd → finish. Runs python3 scripts/cmd/cmd.py $CMD inside CI_IMAGE, uploads artifacts (command-output, command-diff, git-status, git-diff, optional subweight), then applies + pushes the diff with
  rebase-on-conflict retry. Deltas vs. upstream:
    - Dropped label-subcommand branches (cmd.py here implements only bench + fmt).
    - Dropped the use-polkadot-binaries prep step — frame-omni-bencher is provided by the paritytech/ci-unified image.
    - main → dev for the canonical-script clone and the subweight compare baseline.
  - scripts/cmd/cmd.py — added print_and_log + setup_logging so /tmp/cmd/command_output.log is populated for the workflow's PR-comment block. Fixed the fmt branch: replaced an unset RUST_NIGHTLY_VERSION lookup (which was producing cargo +nightly-None fmt) with
  plain cargo +nightly fmt, and fixed a broken non-f-string log line.
