### PR TITLE
fix(ui): point previewnet provider at renamed /web3-storage-provider route

### DIFF
--- a/user-interfaces/shared/network-config/src/networks.ts
+++ b/user-interfaces/shared/network-config/src/networks.ts
@@ -21,7 +21,7 @@ export const PREVIEWNET_NETWORK: NetworkConfig = {
   id: 'previewnet',
   name: 'PreviewNet Testnet',
   parachainWs: 'wss://previewnet.substrate.dev/web3-storage',
-  providerHttp: 'https://previewnet.substrate.dev/provider',
+  providerHttp: 'https://previewnet.substrate.dev/web3-storage-provider',
   relayChainWs: 'wss://previewnet-rpc.polkadot.io',
   isTestnet: true,
 }


### PR DESCRIPTION
Update the previewnet network config so the provider HTTP endpoint targets `https://previewnet.substrate.dev/web3-storage-provider` instead of the old `/provider` path.


Related: paritytech/product-preview-net#134