### PR TITLE
fix(bot): install missing `frame-omni-bencher` in CI for bench

### DIFF
--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -138,6 +138,17 @@ jobs:
           repository: ${{ env.REPO }}
           ref: ${{ env.PR_BRANCH }}
 
+      - name: Install frame-omni-bencher for bench
+        if: startsWith(github.event.inputs.cmd, 'bench')
+        shell: bash
+        run: |
+          set -euxo pipefail
+          source .github/env
+          curl -sSfL -o /usr/local/bin/frame-omni-bencher \
+            "https://github.com/paritytech/polkadot-sdk/releases/download/${POLKADOT_SDK_VERSION}/frame-omni-bencher"
+          chmod +x /usr/local/bin/frame-omni-bencher
+          frame-omni-bencher --version
+
       - name: Run cmd
         id: cmd
         env:


### PR DESCRIPTION
As the cmd bot is failing benchmark due to `frame-omni-bencher` being absent, download just that tagged binary first in CI. Bulletin has a much larger action for bringing in all the polkadot binaries, but here we don't need that much yet.