### PR TITLE
Fix UI bugs across provider dashboard, drive UI, and console UI

### DIFF
--- a/.claude/skills/run-local-uis/landing-vite.config.mjs
+++ b/.claude/skills/run-local-uis/landing-vite.config.mjs
@@ -26,8 +26,18 @@ function readConfig() {
   const networksSrc = readFileSync(NETWORKS_TS, 'utf8')
   const typesSrc = readFileSync(TYPES_TS, 'utf8')
 
-  const defaultId = networksSrc.match(/DEFAULT_NETWORK_ID:\s*NetworkId\s*=\s*'([a-z]+)'/)?.[1]
-  if (!defaultId) throw new Error('could not extract DEFAULT_NETWORK_ID')
+  // `DEFAULT_NETWORK_ID` may be a plain literal or a build-time ternary
+  // (`import.meta.env?.DEV ? 'local' : 'previewnet'`). This is a dev server, so
+  // mirror `import.meta.env.DEV === true` and pick the truthy branch (the
+  // literal right after `?`); fall back to the sole literal otherwise.
+  const defaultExpr = networksSrc.match(
+    /DEFAULT_NETWORK_ID:\s*NetworkId\s*=\s*([\s\S]*?)(?=\n\s*\n|\nexport\b|\nfunction\b)/,
+  )?.[1]
+  if (!defaultExpr) throw new Error('could not extract DEFAULT_NETWORK_ID')
+  const defaultId = defaultExpr.includes('?')
+    ? defaultExpr.match(/\?\s*'([a-z]+)'/)?.[1]
+    : defaultExpr.match(/'([a-z]+)'/)?.[1]
+  if (!defaultId) throw new Error('could not extract DEFAULT_NETWORK_ID literal')
 
   const unionBody = typesSrc.match(/export\s+type\s+NetworkId\s*=\s*([^\n;]+)/)?.[1]
   if (!unionBody) throw new Error('could not extract NetworkId union')

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -287,10 +287,24 @@ jobs:
 
       - name: Install solc and resolc
         run: |
-          curl -L -o /usr/local/bin/solc \
-            "https://github.com/ethereum/solidity/releases/download/v${SOLC_VERSION}/solc-static-linux"
-          curl -L -o /usr/local/bin/resolc \
-            "https://github.com/paritytech/revive/releases/download/v${RESOLC_VERSION}/resolc-x86_64-unknown-linux-musl"
+          for bin_url in \
+            "/usr/local/bin/solc https://github.com/ethereum/solidity/releases/download/v${SOLC_VERSION}/solc-static-linux" \
+            "/usr/local/bin/resolc https://github.com/paritytech/revive/releases/download/v${RESOLC_VERSION}/resolc-x86_64-unknown-linux-musl"; do
+            dest="${bin_url%% *}"
+            url="${bin_url#* }"
+            for attempt in 1 2 3; do
+              echo "Downloading $dest (attempt $attempt/3)..."
+              if curl -L --retry 2 --retry-delay 5 --connect-timeout 30 --max-time 600 \
+                  -o "$dest" "$url"; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "Failed to download $dest after 3 attempts"
+                exit 1
+              fi
+              sleep $((attempt * 5))
+            done
+          done
           chmod +x /usr/local/bin/solc /usr/local/bin/resolc
           solc --version
           resolc --version

--- a/justfile
+++ b/justfile
@@ -60,7 +60,18 @@ _download BIN URL:
         exit 0
     fi
     echo "Downloading {{BIN}}..."
-    curl -L -o .bin/{{BIN}} "{{URL}}"
+    for attempt in 1 2 3; do
+        echo "  attempt $attempt/3 ..."
+        if curl -L --retry 2 --retry-delay 5 --connect-timeout 30 --max-time 600 \
+            -o .bin/{{BIN}} "{{URL}}"; then
+            break
+        fi
+        if [ "$attempt" -eq 3 ]; then
+            echo "Failed to download {{BIN}} after 3 attempts"
+            exit 1
+        fi
+        sleep $((attempt * 5))
+    done
     chmod +x .bin/{{BIN}}
     echo "{{BIN}} downloaded to .bin/{{BIN}}"
 

--- a/user-interfaces/console-ui/src/components/BucketInfoPanel.tsx
+++ b/user-interfaces/console-ui/src/components/BucketInfoPanel.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { useStorage } from "@/hooks/useStorage";
 import { toast } from "@/components/ui/toaster";
 import { truncateHash } from "@/lib/utils";
+import { isSameAddress } from "@web3-storage/papi";
 import type { BucketMember, ProviderEndpointInfo } from "@/lib/storage";
 
 interface BucketInfoPanelProps {
@@ -40,9 +41,13 @@ export default function BucketInfoPanel({ bucketId }: BucketInfoPanelProps) {
   const [newMemberRole, setNewMemberRole] = useState<'Admin' | 'Writer' | 'Reader'>('Writer');
   const [adding, setAdding] = useState(false);
 
-  const isAdmin = members.some(
-    (m) => m.account === signerAddress && m.role === 'Admin'
-  );
+  // Compare by raw bytes: member accounts come from chain (runtime prefix)
+  // while signerAddress is locally encoded, so string equality can fail across
+  // SS58 prefixes.
+  const isMe = (account: string) =>
+    signerAddress != null && isSameAddress(account, signerAddress);
+
+  const isAdmin = members.some((m) => isMe(m.account) && m.role === 'Admin');
 
   const refreshMembers = useCallback(async () => {
     setLoadingMembers(true);
@@ -81,7 +86,7 @@ export default function BucketInfoPanel({ bucketId }: BucketInfoPanelProps) {
     // The runtime's set_member updates an existing member's role rather
     // than rejecting; surface the duplicate at the UI layer so users get
     // an obvious "already a member" message instead of a silent role swap.
-    if (members.some((m) => m.account === trimmed)) {
+    if (members.some((m) => isSameAddress(m.account, trimmed))) {
       toast({
         title: "Failed to add member",
         description: `${truncateHash(trimmed)} is already a member`,
@@ -100,7 +105,7 @@ export default function BucketInfoPanel({ bucketId }: BucketInfoPanelProps) {
       // list. Reconciliation happens on the next expand or via the
       // manual refresh button. Mirrors useStorage.createBucket.
       setMembers((prev) =>
-        prev.some((m) => m.account === trimmed)
+        prev.some((m) => isSameAddress(m.account, trimmed))
           ? prev
           : [...prev, { account: trimmed, role: newMemberRole }],
       );
@@ -236,7 +241,7 @@ export default function BucketInfoPanel({ bucketId }: BucketInfoPanelProps) {
                       <td className="py-1.5">{roleBadge(m.role)}</td>
                       {isAdmin && (
                         <td className="py-1.5 text-right">
-                          {m.account !== signerAddress && (
+                          {!isMe(m.account) && (
                             <Button
                               data-testid={`bucket-member-remove-${m.account}`}
                               variant="ghost"

--- a/user-interfaces/console-ui/src/components/Layout.tsx
+++ b/user-interfaces/console-ui/src/components/Layout.tsx
@@ -15,6 +15,7 @@ const LANDING_URL = import.meta.env.DEV ? "http://127.0.0.1:5176/" : "../";
 import { useChain } from "@/hooks/useChain";
 import { useStorage } from "@/hooks/useStorage";
 import { useNetworkSelection } from "@/state/network.state";
+import { withNetworkHandoff } from "@web3-storage/network-config";
 import { NetworkPicker } from "@web3-storage/network-picker";
 import { Button } from "@/components/ui/button";
 import { cn, truncateHash, formatTokens } from "@/lib/utils";
@@ -43,7 +44,7 @@ export default function Layout() {
       <div className="hidden w-64 flex-col border-r bg-card md:flex">
         <div className="flex h-14 items-center border-b px-4 gap-2">
           <a
-            href={LANDING_URL}
+            href={withNetworkHandoff(LANDING_URL, selectedNetwork)}
             data-testid="back-to-landing"
             title="Back to home"
             className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"

--- a/user-interfaces/console-ui/src/components/S3Tab.tsx
+++ b/user-interfaces/console-ui/src/components/S3Tab.tsx
@@ -25,6 +25,7 @@ import {
 import { useStorage } from "@/hooks/useStorage";
 import { toast } from "@/components/ui/toaster";
 import { formatBytes, truncateHash } from "@/lib/utils";
+import { isSameAddress } from "@web3-storage/papi";
 import type { BucketInfo, S3ObjectInfo } from "@/lib/storage";
 import { EncryptionKey, bytesToHex } from "@/lib/encryption";
 import CreationStatusCard, { type CreationStatusItem } from "./CreationStatusCard";
@@ -108,13 +109,13 @@ export default function S3Tab({ onBucketSelect }: S3TabProps) {
     // The bucket owner is always Admin (the on-chain creator is added as Admin
     // in the pallet, but the member query can fail or return a format that
     // doesn't match the signer address string).
-    if (selectedBucket.owner === signerAddress) {
+    if (isSameAddress(selectedBucket.owner, signerAddress)) {
       setUserRole('Admin');
       return;
     }
     fetchBucketMembers(selectedBucket.layer0BucketId)
       .then((members) => {
-        const me = members.find((m) => m.account === signerAddress);
+        const me = members.find((m) => isSameAddress(m.account, signerAddress));
         setUserRole(me?.role ?? null);
       })
       .catch(() => setUserRole(null));

--- a/user-interfaces/console-ui/src/components/S3Tab.tsx
+++ b/user-interfaces/console-ui/src/components/S3Tab.tsx
@@ -69,8 +69,6 @@ export default function S3Tab({ onBucketSelect }: S3TabProps) {
   const [bucketCapacity, setBucketCapacity] = useState("10485760");
   const [bucketDuration, setBucketDuration] = useState("10000");
   const [bucketMaxPayment, setBucketMaxPayment] = useState("120000000000000000");
-  const [creating, setCreating] = useState(false);
-
   // Creation status tracking
   const [creations, setCreations] = useState<CreationStatusItem[]>([]);
   const [pickerTarget, setPickerTarget] = useState<CreationStatusItem | null>(null);
@@ -191,18 +189,20 @@ export default function S3Tab({ onBucketSelect }: S3TabProps) {
     return true;
   };
 
-  const waitAndTrack = async (creationId: string, layer0BucketId: bigint) => {
+  const waitAndTrack = async (creationId: string, layer0BucketId: bigint): Promise<boolean> => {
     updateCreation(creationId, { stage: "waiting", elapsedMs: 0 });
     try {
       await waitForProvider(layer0BucketId, (status, elapsedMs) => {
         updateCreation(creationId, { statusMessage: status, elapsedMs });
       });
       updateCreation(creationId, { stage: "ready" });
+      return true;
     } catch (err) {
       updateCreation(creationId, {
         stage: "failed",
         error: err instanceof Error ? err.message : "Provider did not accept. Try choosing a provider manually.",
       });
+      return false;
     }
   };
 
@@ -214,29 +214,47 @@ export default function S3Tab({ onBucketSelect }: S3TabProps) {
       return;
     }
 
-    setCreating(true);
+    const creationId = crypto.randomUUID();
+    const name = newBucketName;
+
+    setCreations(prev => [...prev, {
+      id: creationId,
+      name,
+      type: "bucket",
+      stage: "submitting",
+      elapsedMs: 0,
+      createdAt: Date.now(),
+    }]);
+
+    // Close the form so the user sees the status card
+    setShowCreateBucket(false);
+    setNewBucketName("");
     setCreateError(null);
 
     try {
-      const bucket = await createBucket(newBucketName, {
+      const bucket = await createBucket(name, {
         capacity: BigInt(bucketCapacity),
         duration: parseInt(bucketDuration, 10),
         maxPayment: BigInt(bucketMaxPayment),
       });
-      setSelectedBucket(bucket);
-      setShowCreateBucket(false);
-      setNewBucketName("");
-      toast({ title: "Success", description: `Bucket "${bucket.name}" created` });
+
+      updateCreation(creationId, { stage: "created", bucketId: bucket.layer0BucketId });
+
+      // Poll for provider acceptance in the background
+      waitAndTrack(creationId, bucket.layer0BucketId).then((ready) => {
+        if (!ready) return;
+        // Provider accepted — select the bucket and refresh the list
+        refreshBuckets();
+        setSelectedBucket(bucket);
+        onBucketSelect?.(bucket.layer0BucketId);
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to create bucket";
-      // Show friendly error for common cases
+      let errorMsg = msg;
       if (msg.includes("NoProvidersAvailable")) {
-        setCreateError("No storage providers available. Make sure a provider is running and accepting agreements.");
-      } else {
-        setCreateError(msg);
+        errorMsg = "No storage providers available. Make sure a provider is running and accepting agreements.";
       }
-    } finally {
-      setCreating(false);
+      updateCreation(creationId, { stage: "failed", error: errorMsg });
     }
   };
 
@@ -461,10 +479,10 @@ export default function S3Tab({ onBucketSelect }: S3TabProps) {
               <p data-testid="s3-create-error" className="text-sm text-destructive">{createError}</p>
             )}
             <div className="flex gap-2">
-              <Button data-testid="s3-create-submit" onClick={handleCreateBucket} disabled={creating || loading}>
-                {creating ? <><RefreshCw className="mr-2 h-4 w-4 animate-spin" />Submitting...</> : "Create"}
+              <Button data-testid="s3-create-submit" onClick={handleCreateBucket} disabled={loading}>
+                Create
               </Button>
-              <Button data-testid="s3-create-cancel" variant="ghost" onClick={() => { setShowCreateBucket(false); setCreateError(null); }} disabled={creating}>Cancel</Button>
+              <Button data-testid="s3-create-cancel" variant="ghost" onClick={() => { setShowCreateBucket(false); setCreateError(null); }}>Cancel</Button>
             </div>
           </CardContent>
         </Card>

--- a/user-interfaces/console-ui/src/hooks/useChain.tsx
+++ b/user-interfaces/console-ui/src/hooks/useChain.tsx
@@ -8,7 +8,9 @@ import {
 } from "react";
 import { createClient, type PolkadotClient } from "polkadot-api";
 import { getWsProvider } from "polkadot-api/ws";
+import { parachain } from "@polkadot-api/descriptors";
 import { BehaviorSubject } from "rxjs";
+import { setSs58Prefix } from "@web3-storage/papi";
 import { loadSelectedNetwork } from "@web3-storage/network-config";
 
 const initialEndpoint = loadSelectedNetwork().config.parachainWs;
@@ -67,6 +69,15 @@ export function ChainProvider({ children }: { children: ReactNode }) {
 
         setClient(newClient);
         setConnected(true);
+
+        // Render addresses with the runtime's SS58 prefix (per-network).
+        try {
+          setSs58Prefix(
+            await newClient.getTypedApi(parachain).constants.System.SS58Prefix(),
+          );
+        } catch {
+          /* keep the default prefix */
+        }
 
         // Store cleanup
         (newClient as unknown as { _unsub: () => void })._unsub = unsub.unsubscribe.bind(unsub);

--- a/user-interfaces/console-ui/src/lib/crypto.ts
+++ b/user-interfaces/console-ui/src/lib/crypto.ts
@@ -12,11 +12,10 @@ import {
   entropyToMiniSecret,
   mnemonicToEntropy,
 } from "@polkadot-labs/hdkd-helpers";
-import { fromBufferToBase58 } from "@polkadot-api/substrate-bindings";
 
-// System parachain `SS58_PREFIX` is 0
-const SS58_PREFIX = 0;
-export const toSs58 = fromBufferToBase58(SS58_PREFIX);
+// SS58 encoding (prefix + helper) lives in the shared PAPI package so every UI
+// renders addresses with the same, runtime-derived prefix.
+export { toSs58 } from "@web3-storage/papi";
 
 export interface Keypair {
   publicKey: Uint8Array;

--- a/user-interfaces/console-ui/src/pages/Accounts.tsx
+++ b/user-interfaces/console-ui/src/pages/Accounts.tsx
@@ -22,6 +22,7 @@ import { truncateHash } from "@/lib/utils";
 import { useChain } from "@/hooks/useChain";
 import { useStorage } from "@/hooks/useStorage";
 import { seedToKeypair, toSs58 } from "@/lib/crypto";
+import { isSameAddress } from "@web3-storage/papi";
 
 interface Account {
   name: string;
@@ -51,7 +52,14 @@ export default function Accounts() {
   const [customName, setCustomName] = useState("");
   const [settingAccount, setSettingAccount] = useState<string | null>(null);
 
-  const isActive = (account: Account) => account.address === signerAddress;
+  // Compare by raw bytes: dev-account addresses are encoded at module load
+  // (default prefix) while `signerAddress` follows the connected runtime, so
+  // string equality can spuriously fail across prefixes.
+  const isActive = (account: Account) =>
+    signerAddress != null && isSameAddress(account.address, signerAddress);
+
+  const isDevAccount = (address: string) =>
+    DEV_ACCOUNTS.some((d) => isSameAddress(d.address, address));
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text);
@@ -128,7 +136,7 @@ export default function Accounts() {
 
   const handleDeleteAccount = (address: string) => {
     // Don't allow deleting dev accounts
-    if (DEV_ACCOUNTS.some((a) => a.address === address)) {
+    if (isDevAccount(address)) {
       toast({
         title: "Error",
         description: "Cannot delete dev accounts",
@@ -297,7 +305,7 @@ export default function Accounts() {
                           Active
                         </span>
                       )}
-                      {DEV_ACCOUNTS.some((d) => d.address === account.address) && (
+                      {isDevAccount(account.address) && (
                         <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded">
                           Dev
                         </span>
@@ -336,7 +344,7 @@ export default function Accounts() {
                   >
                     <Copy className="h-4 w-4" />
                   </Button>
-                  {!DEV_ACCOUNTS.some((d) => d.address === account.address) && (
+                  {!isDevAccount(account.address) && (
                     <Button
                       data-testid={`accounts-delete-${account.name}`}
                       variant="ghost"

--- a/user-interfaces/drive-ui/src/components/Layout.tsx
+++ b/user-interfaces/drive-ui/src/components/Layout.tsx
@@ -16,6 +16,7 @@ import {
   selectNetwork,
   selectCustomNetwork,
 } from "@/state/network.state";
+import { withNetworkHandoff } from "@web3-storage/network-config";
 import { NetworkPicker } from "@web3-storage/network-picker";
 import { formatTokens, truncateHash } from "@/lib/utils";
 import DriveList from "./DriveList";
@@ -38,7 +39,7 @@ export default function Layout() {
       <aside className="w-64 flex-shrink-0 border-r bg-card flex flex-col">
         <div className="flex items-center gap-2.5 px-4 py-4 border-b">
           <a
-            href={LANDING_URL}
+            href={withNetworkHandoff(LANDING_URL, selectedNetwork)}
             data-testid="back-to-landing"
             title="Back to home"
             className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"

--- a/user-interfaces/drive-ui/src/components/ManageAccessDialog.tsx
+++ b/user-interfaces/drive-ui/src/components/ManageAccessDialog.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Users, Plus, Trash2, RefreshCw } from "lucide-react";
 import { isValidSs58 } from "@/lib/crypto";
+import { isSameAddress } from "@web3-storage/papi";
 import {
   Dialog,
   DialogContent,
@@ -57,11 +58,14 @@ export default function ManageAccessDialog({
   const [adding, setAdding] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
-  const isAdmin = members.some(
-    (m) => m.account === signerAddress && m.role === "Admin",
-  );
+  // Compare by raw bytes: member accounts come from chain (runtime prefix)
+  // while signerAddress / typed input may use a different SS58 prefix.
+  const isMe = (account: string) =>
+    signerAddress != null && isSameAddress(account, signerAddress);
+  const isMember = (account: string) =>
+    members.some((m) => isSameAddress(m.account, account));
 
-  const memberAddresses = useMemo(() => new Set(members.map((m) => m.account)), [members]);
+  const isAdmin = members.some((m) => isMe(m.account) && m.role === "Admin");
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -89,12 +93,12 @@ export default function ManageAccessDialog({
       setValidationError("Invalid SS58 address");
       return;
     }
-    if (memberAddresses.has(newAccount.trim())) {
+    if (isMember(newAccount.trim())) {
       setValidationError("This account is already a member");
       return;
     }
     setValidationError(null);
-  }, [newAccount, memberAddresses]);
+  }, [newAccount, members]);
 
   const handleAdd = async () => {
     const trimmed = newAccount.trim();
@@ -103,7 +107,7 @@ export default function ManageAccessDialog({
       setValidationError("Invalid SS58 address");
       return;
     }
-    if (memberAddresses.has(trimmed)) {
+    if (isMember(trimmed)) {
       setValidationError("This account is already a member");
       return;
     }
@@ -193,7 +197,7 @@ export default function ManageAccessDialog({
                       <td className="py-1.5">{roleBadge(m.role)}</td>
                       {isAdmin && (
                         <td className="py-1.5 text-right">
-                          {m.account !== signerAddress && (
+                          {!isMe(m.account) && (
                             <Button
                               data-testid={`member-remove-${m.account}`}
                               variant="ghost"

--- a/user-interfaces/drive-ui/src/components/NewFolderDialog.tsx
+++ b/user-interfaces/drive-ui/src/components/NewFolderDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Loader2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -13,7 +14,7 @@ import { Input } from "@/components/ui/input";
 interface NewFolderDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (name: string) => void;
+  onConfirm: (name: string) => Promise<void>;
 }
 
 export default function NewFolderDialog({
@@ -22,17 +23,24 @@ export default function NewFolderDialog({
   onConfirm,
 }: NewFolderDialogProps) {
   const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
 
-  const handleSubmit = () => {
-    if (name.trim()) {
-      onConfirm(name.trim());
+  const handleSubmit = async () => {
+    if (!name.trim() || creating) return;
+    setCreating(true);
+    try {
+      await onConfirm(name.trim());
       setName("");
       onOpenChange(false);
+    } catch {
+      // Error toast is handled by the caller (useDrive.createFolder)
+    } finally {
+      setCreating(false);
     }
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={(v) => { if (!creating) onOpenChange(v); }}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>New Folder</DialogTitle>
@@ -46,13 +54,21 @@ export default function NewFolderDialog({
           placeholder="Folder name"
           onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
           autoFocus
+          disabled={creating}
         />
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={!name.trim()}>
-            Create
+          <Button onClick={handleSubmit} disabled={!name.trim() || creating}>
+            {creating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              "Create"
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/user-interfaces/drive-ui/src/lib/crypto.ts
+++ b/user-interfaces/drive-ui/src/lib/crypto.ts
@@ -11,14 +11,11 @@ import {
   entropyToMiniSecret,
   mnemonicToEntropy,
 } from "@polkadot-labs/hdkd-helpers";
-import {
-  fromBufferToBase58,
-  getSs58AddressInfo,
-} from "@polkadot-api/substrate-bindings";
+import { getSs58AddressInfo } from "@polkadot-api/substrate-bindings";
 
-// System parachain `SS58_PREFIX `is 0
-const SS58_PREFIX = 0;
-export const toSs58 = fromBufferToBase58(SS58_PREFIX);
+// SS58 encoding (prefix + helper) lives in the shared PAPI package so every UI
+// renders addresses with the same, runtime-derived prefix.
+export { toSs58 } from "@web3-storage/papi";
 
 export interface Keypair {
   publicKey: Uint8Array;

--- a/user-interfaces/drive-ui/src/lib/drive-client.ts
+++ b/user-interfaces/drive-ui/src/lib/drive-client.ts
@@ -112,10 +112,13 @@ async function httpFetch(
  * HTTP URL. Picks the FIRST matching host/port pair so multi-`/tcp/` addrs
  * with multiple host candidates resolve deterministically.
  */
-function decodeName(name: Uint8Array | undefined): string | null {
-  if (!name) return null;
+function decodeName(name: unknown): string | null {
+  if (name == null) return null;
   try {
-    return new TextDecoder().decode(name);
+    if (typeof name === "string") return name;
+    // polkadot-api Binary has asText(); fall back to TextDecoder
+    if (typeof (name as any).asText === "function") return (name as any).asText();
+    return new TextDecoder().decode(name as Uint8Array);
   } catch {
     return null;
   }

--- a/user-interfaces/drive-ui/src/state/chain.state.ts
+++ b/user-interfaces/drive-ui/src/state/chain.state.ts
@@ -10,6 +10,7 @@ import { bind } from "@react-rxjs/core";
 import { createClient, type PolkadotClient, type TypedApi } from "polkadot-api";
 import { getWsProvider } from "polkadot-api/ws";
 import { parachain } from "@polkadot-api/descriptors";
+import { setSs58Prefix } from "@web3-storage/papi";
 import { loadSelectedNetwork } from "@web3-storage/network-config";
 
 export type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
@@ -66,6 +67,15 @@ export async function connect(wsEndpoint?: string): Promise<void> {
 
     client$.next(client);
     api$.next(api);
+
+    // Render addresses with the runtime's SS58 prefix (per-network). Dev-account
+    // addresses are re-derived lazily on every setSigner(), so they pick this up.
+    try {
+      setSs58Prefix(await api.constants.System.SS58Prefix());
+    } catch {
+      /* keep the default prefix */
+    }
+
     connectionStatus$.next("connected");
   } catch (error) {
     connectionStatus$.next("error");

--- a/user-interfaces/drive-ui/src/state/drive.state.ts
+++ b/user-interfaces/drive-ui/src/state/drive.state.ts
@@ -15,7 +15,7 @@ import {
   type CreateDriveOptions,
 } from "@/lib/drive-client";
 import { api$$, getApi } from "@/state/chain.state";
-import { signer$$, getSignerAddress, refreshBalance } from "@/state/wallet.state";
+import { signer$$, signerAddress$$, getSignerAddress, refreshBalance } from "@/state/wallet.state";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -422,10 +422,15 @@ api$$.subscribe(() => {
 // when (selectedDrive, currentPath) change.
 // ─────────────────────────────────────────────────────────────────────────────
 
-combineLatest([api$$, signer$$])
-  .pipe(distinctUntilChanged())
-  .subscribe(([api, signer]) => {
-    if (api && signer) {
+combineLatest([api$$, signerAddress$$])
+  .pipe(distinctUntilChanged((a, b) => a[0] === b[0] && a[1] === b[1]))
+  .subscribe(([api, address]) => {
+    if (api && address) {
+      // Clear previous user's state before loading the new user's drives
+      drives$.next([]);
+      selectedDrive$.next(null);
+      entries$.next([]);
+      currentPath$.next("/");
       refreshDrives().catch(() => { /* swallow */ });
     } else {
       drives$.next([]);

--- a/user-interfaces/drive-ui/src/state/drive.state.ts
+++ b/user-interfaces/drive-ui/src/state/drive.state.ts
@@ -72,8 +72,11 @@ api$$.subscribe((api) => {
   client.setApi(api);
 });
 
-signer$$.subscribe((signer) => {
-  client.setSigner(signer, getSignerAddress());
+// Use combineLatest so the client always receives signer + address together.
+// With separate subscriptions, signer$ fires before signerAddress$ inside
+// setSigner(), leaving client.signerAddress null when refreshDrives() runs.
+combineLatest([signer$$, signerAddress$$]).subscribe(([signer, address]) => {
+  client.setSigner(signer, address);
 });
 
 export function getDriveClient(): DriveClient {

--- a/user-interfaces/landing/index.html
+++ b/user-interfaces/landing/index.html
@@ -273,6 +273,31 @@
       }
     } catch (e) { /* ignore */ }
 
+    // Network handoff from an app's "back to home" link (?network=...). Takes
+    // precedence over the persisted selection (an app on its own origin in dev
+    // can't share localStorage), persists it, then strips the params so a
+    // refresh doesn't re-apply a stale handoff.
+    try {
+      var hp = new URLSearchParams(window.location.search);
+      var incoming = hp.get('network');
+      if (incoming && VALID_IDS.indexOf(incoming) !== -1) {
+        select.value = incoming;
+        localStorage.setItem('web3-storage-selected-network', incoming);
+        if (incoming === 'custom') {
+          var iws = hp.get('parachainWs');
+          var ihttp = hp.get('providerHttp');
+          if (iws) customWs.value = iws;
+          if (ihttp) customHttp.value = ihttp;
+          if (iws && ihttp) {
+            localStorage.setItem('web3-storage-custom-network', JSON.stringify({ parachainWs: iws, providerHttp: ihttp }));
+          }
+        }
+        hp.delete('network'); hp.delete('parachainWs'); hp.delete('providerHttp');
+        var hqs = hp.toString();
+        window.history.replaceState({}, '', window.location.pathname + (hqs ? '?' + hqs : '') + window.location.hash);
+      }
+    } catch (e) { /* ignore */ }
+
     function setEndpoint(el, value, placeholder) {
       if (value) {
         el.textContent = value;

--- a/user-interfaces/pnpm-lock.yaml
+++ b/user-interfaces/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       '@web3-storage/network-picker':
         specifier: workspace:*
         version: link:../shared/network-picker
+      '@web3-storage/papi':
+        specifier: workspace:*
+        version: link:../shared/papi
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -388,6 +391,9 @@ importers:
       '@polkadot-api/descriptors':
         specifier: file:.papi/descriptors
         version: link:.papi/descriptors
+      '@polkadot-labs/hdkd-helpers':
+        specifier: ^0.0.30
+        version: 0.0.30
     devDependencies:
       '@polkadot-api/cli':
         specifier: ^0.20.4
@@ -1497,36 +1503,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1591,66 +1603,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1766,24 +1791,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -2429,24 +2458,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/user-interfaces/pnpm-lock.yaml
+++ b/user-interfaces/pnpm-lock.yaml
@@ -434,6 +434,9 @@ importers:
       '@polkadot-labs/hdkd-helpers':
         specifier: ^0.0.30
         version: 0.0.30
+      '@web3-storage/papi':
+        specifier: workspace:*
+        version: link:../papi
       polkadot-api:
         specifier: ^2.1.0
         version: 2.1.1(esbuild@0.28.0)(rxjs@7.8.2)

--- a/user-interfaces/provider/package.json
+++ b/user-interfaces/provider/package.json
@@ -29,6 +29,7 @@
     "@react-rxjs/core": "^0.10.8",
     "@react-rxjs/utils": "^0.9.7",
     "@web3-storage/network-config": "workspace:*",
+    "@web3-storage/papi": "workspace:*",
     "@web3-storage/network-picker": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/user-interfaces/provider/src/components/Header.tsx
+++ b/user-interfaces/provider/src/components/Header.tsx
@@ -28,6 +28,7 @@ import {
   selectAccount,
   disconnectWallet,
 } from '@/state/wallet.state'
+import { withNetworkHandoff } from '@web3-storage/network-config'
 import { NetworkPicker } from '@web3-storage/network-picker'
 import {
   useSelectedNetwork,
@@ -142,7 +143,7 @@ export function Header() {
           {/* Logo */}
           <div className="flex items-center gap-3">
             <a
-              href={LANDING_URL}
+              href={withNetworkHandoff(LANDING_URL, selectedNetwork)}
               data-testid="back-to-landing"
               title="Back to home"
               className="flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-100 hover:bg-gray-800 transition-colors"

--- a/user-interfaces/provider/src/lib/chain-client.ts
+++ b/user-interfaces/provider/src/lib/chain-client.ts
@@ -12,7 +12,7 @@ import { getWsProvider } from 'polkadot-api/ws'
 import { type InjectedPolkadotAccount } from 'polkadot-api/pjs-signer'
 import { parachain } from '@polkadot-api/descriptors'
 import { BehaviorSubject } from 'rxjs'
-import { isSameAddress } from '@web3-storage/papi'
+import { getSs58Prefix, isSameAddress } from '@web3-storage/papi'
 
 export type { PolkadotClient }
 type ParachainApi = TypedApi<typeof parachain>
@@ -83,7 +83,7 @@ export async function getChainProperties(): Promise<{
   let tokenSymbol = 'UNIT'
   let blockTimeMs = 6000
   let minProviderStake = 1_000_000_000_000_000n
-  let ss58Prefix = 0
+  let ss58Prefix = getSs58Prefix()
 
   if (client && api) {
     try {

--- a/user-interfaces/provider/src/lib/chain-client.ts
+++ b/user-interfaces/provider/src/lib/chain-client.ts
@@ -12,22 +12,7 @@ import { getWsProvider } from 'polkadot-api/ws'
 import { type InjectedPolkadotAccount } from 'polkadot-api/pjs-signer'
 import { parachain } from '@polkadot-api/descriptors'
 import { BehaviorSubject } from 'rxjs'
-import { ss58Decode } from '@polkadot-labs/hdkd-helpers'
-
-/** Compare two SS58 addresses by raw public key bytes (prefix-agnostic). */
-function sameAddress(a: string, b: string): boolean {
-  try {
-    const [aBytes] = ss58Decode(a)
-    const [bBytes] = ss58Decode(b)
-    if (aBytes.length !== bBytes.length) return false
-    for (let i = 0; i < aBytes.length; i++) {
-      if (aBytes[i] !== bBytes[i]) return false
-    }
-    return true
-  } catch {
-    return false
-  }
-}
+import { isSameAddress } from '@web3-storage/papi'
 
 export type { PolkadotClient }
 type ParachainApi = TypedApi<typeof parachain>
@@ -90,6 +75,7 @@ export async function getChainProperties(): Promise<{
   tokenSymbol: string
   blockTimeMs: number
   minProviderStake: bigint
+  ss58Prefix: number
 }> {
   // Defaults match the current runtime; overridden where the chain exposes
   // them via constants / spec data.
@@ -97,11 +83,12 @@ export async function getChainProperties(): Promise<{
   let tokenSymbol = 'UNIT'
   let blockTimeMs = 6000
   let minProviderStake = 1_000_000_000_000_000n
+  let ss58Prefix = 0
 
   if (client && api) {
     try {
       const spec = await client.getChainSpecData()
-      const props = spec.properties as { tokenDecimals?: number | number[]; tokenSymbol?: string | string[] } | undefined
+      const props = spec.properties as { tokenDecimals?: number | number[]; tokenSymbol?: string | string[]; ss58Format?: number } | undefined
       if (props) {
         const dec = props.tokenDecimals
         if (typeof dec === 'number') tokenDecimals = dec
@@ -109,8 +96,14 @@ export async function getChainProperties(): Promise<{
         const sym = props.tokenSymbol
         if (typeof sym === 'string') tokenSymbol = sym
         else if (Array.isArray(sym) && sym.length > 0) tokenSymbol = sym[0]
+        if (typeof props.ss58Format === 'number') ss58Prefix = props.ss58Format
       }
     } catch { /* use defaults */ }
+
+    // If chain spec didn't have ss58Format, try the runtime constant
+    try {
+      ss58Prefix = await api.constants.System.SS58Prefix()
+    } catch { /* use default */ }
 
     try {
       minProviderStake = await api.constants.StorageProvider.MinProviderStake()
@@ -123,7 +116,7 @@ export async function getChainProperties(): Promise<{
     } catch { /* use default */ }
   }
 
-  return { tokenDecimals, tokenSymbol, blockTimeMs, minProviderStake }
+  return { tokenDecimals, tokenSymbol, blockTimeMs, minProviderStake, ss58Prefix }
 }
 
 export async function getGenesisHash(): Promise<string> {
@@ -363,7 +356,7 @@ export async function getProviderAgreements(address: string): Promise<OnChainAgr
   const out: OnChainAgreement[] = []
   for (const { keyArgs, value } of entries) {
     const [bucketIdRaw, providerAddr] = keyArgs
-    if (!sameAddress(providerAddr, address)) continue
+    if (!isSameAddress(providerAddr, address)) continue
     const bucketId = Number(bucketIdRaw)
     const expiresAt = value.expires_at
     let status: 'active' | 'expired' | 'terminated' = 'active'
@@ -391,7 +384,7 @@ export async function getAgreementRequests(address: string): Promise<OnChainAgre
   const out: OnChainAgreementRequest[] = []
   for (const { keyArgs, value } of entries) {
     const [bucketIdRaw, providerAddr] = keyArgs
-    if (!sameAddress(providerAddr, address)) continue
+    if (!isSameAddress(providerAddr, address)) continue
     out.push({
       bucketId: Number(bucketIdRaw),
       requester: value.requester,
@@ -515,7 +508,7 @@ export async function getProviderChallenges(address: string): Promise<OnChainCha
     const deadline = Number(keyArgs[0])
     for (let idx = 0; idx < value.length; idx++) {
       const ch = value[idx]
-      if (!sameAddress(ch.provider, address)) continue
+      if (!isSameAddress(ch.provider, address)) continue
       challenges.push({
         id: idx,
         bucketId: Number(ch.bucket_id),
@@ -639,7 +632,7 @@ export function subscribeToChallengeEvents(
   const created = a.event.StorageProvider.ChallengeCreated.watch().subscribe({
     next: ({ block, events }) => {
       for (const { payload } of events) {
-        if (!sameAddress(payload.provider, address)) continue
+        if (!isSameAddress(payload.provider, address)) continue
         onChallenge({
           id: payload.challenge_id.index,
           bucketId: Number(payload.bucket_id),
@@ -662,7 +655,7 @@ export function subscribeToChallengeEvents(
   const defended = a.event.StorageProvider.ChallengeDefended.watch().subscribe({
     next: ({ events }) => {
       for (const { payload } of events) {
-        if (!sameAddress(payload.provider, address)) continue
+        if (!isSameAddress(payload.provider, address)) continue
         onChallenge({
           id: Number(payload.challenge_id.index),
           bucketId: 0,
@@ -680,7 +673,7 @@ export function subscribeToChallengeEvents(
   const slashed = a.event.StorageProvider.ChallengeSlashed.watch().subscribe({
     next: ({ events }) => {
       for (const { payload } of events) {
-        if (!sameAddress(payload.provider, address)) continue
+        if (!isSameAddress(payload.provider, address)) continue
         onChallenge({
           id: Number(payload.challenge_id.index),
           bucketId: 0,

--- a/user-interfaces/provider/src/lib/chain-client.ts
+++ b/user-interfaces/provider/src/lib/chain-client.ts
@@ -12,6 +12,22 @@ import { getWsProvider } from 'polkadot-api/ws'
 import { type InjectedPolkadotAccount } from 'polkadot-api/pjs-signer'
 import { parachain } from '@polkadot-api/descriptors'
 import { BehaviorSubject } from 'rxjs'
+import { ss58Decode } from '@polkadot-labs/hdkd-helpers'
+
+/** Compare two SS58 addresses by raw public key bytes (prefix-agnostic). */
+function sameAddress(a: string, b: string): boolean {
+  try {
+    const [aBytes] = ss58Decode(a)
+    const [bBytes] = ss58Decode(b)
+    if (aBytes.length !== bBytes.length) return false
+    for (let i = 0; i < aBytes.length; i++) {
+      if (aBytes[i] !== bBytes[i]) return false
+    }
+    return true
+  } catch {
+    return false
+  }
+}
 
 export type { PolkadotClient }
 type ParachainApi = TypedApi<typeof parachain>
@@ -347,7 +363,7 @@ export async function getProviderAgreements(address: string): Promise<OnChainAgr
   const out: OnChainAgreement[] = []
   for (const { keyArgs, value } of entries) {
     const [bucketIdRaw, providerAddr] = keyArgs
-    if (providerAddr !== address) continue
+    if (!sameAddress(providerAddr, address)) continue
     const bucketId = Number(bucketIdRaw)
     const expiresAt = value.expires_at
     let status: 'active' | 'expired' | 'terminated' = 'active'
@@ -375,7 +391,7 @@ export async function getAgreementRequests(address: string): Promise<OnChainAgre
   const out: OnChainAgreementRequest[] = []
   for (const { keyArgs, value } of entries) {
     const [bucketIdRaw, providerAddr] = keyArgs
-    if (providerAddr !== address) continue
+    if (!sameAddress(providerAddr, address)) continue
     out.push({
       bucketId: Number(bucketIdRaw),
       requester: value.requester,
@@ -499,7 +515,7 @@ export async function getProviderChallenges(address: string): Promise<OnChainCha
     const deadline = Number(keyArgs[0])
     for (let idx = 0; idx < value.length; idx++) {
       const ch = value[idx]
-      if (ch.provider !== address) continue
+      if (!sameAddress(ch.provider, address)) continue
       challenges.push({
         id: idx,
         bucketId: Number(ch.bucket_id),
@@ -623,7 +639,7 @@ export function subscribeToChallengeEvents(
   const created = a.event.StorageProvider.ChallengeCreated.watch().subscribe({
     next: ({ block, events }) => {
       for (const { payload } of events) {
-        if (payload.provider !== address) continue
+        if (!sameAddress(payload.provider, address)) continue
         onChallenge({
           id: payload.challenge_id.index,
           bucketId: Number(payload.bucket_id),
@@ -646,7 +662,7 @@ export function subscribeToChallengeEvents(
   const defended = a.event.StorageProvider.ChallengeDefended.watch().subscribe({
     next: ({ events }) => {
       for (const { payload } of events) {
-        if (payload.provider !== address) continue
+        if (!sameAddress(payload.provider, address)) continue
         onChallenge({
           id: Number(payload.challenge_id.index),
           bucketId: 0,
@@ -664,7 +680,7 @@ export function subscribeToChallengeEvents(
   const slashed = a.event.StorageProvider.ChallengeSlashed.watch().subscribe({
     next: ({ events }) => {
       for (const { payload } of events) {
-        if (payload.provider !== address) continue
+        if (!sameAddress(payload.provider, address)) continue
         onChallenge({
           id: Number(payload.challenge_id.index),
           bucketId: 0,

--- a/user-interfaces/provider/src/pages/Agreements.tsx
+++ b/user-interfaces/provider/src/pages/Agreements.tsx
@@ -9,9 +9,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table'
-import { useAgreements } from '@/state/provider.state'
+import { useAgreements, useAgreementRequests } from '@/state/provider.state'
 import { RequireProvider } from '@/components/RequireProvider'
-import { formatAddress, formatBytes, formatTokens, formatBlockNumber } from '@/utils/format'
+import { formatAddress, formatBytes, formatTokens, formatBlockNumber, formatDuration } from '@/utils/format'
 
 export function Agreements() {
   return (
@@ -23,6 +23,7 @@ export function Agreements() {
 
 function AgreementsContent() {
   const agreements = useAgreements()
+  const agreementRequests = useAgreementRequests()
   const activeAgreements = agreements.filter((a) => a.status === 'active')
   const expiredAgreements = agreements.filter((a) => a.status !== 'active')
 
@@ -34,7 +35,15 @@ function AgreementsContent() {
       </div>
 
       {/* Stats */}
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-400">Pending Requests</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{agreementRequests.length}</div>
+          </CardContent>
+        </Card>
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium text-gray-400">Active</CardTitle>
@@ -71,6 +80,48 @@ function AgreementsContent() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Pending Requests */}
+      {agreementRequests.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Pending Requests</CardTitle>
+            <CardDescription>Agreement requests awaiting acceptance</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Bucket</TableHead>
+                  <TableHead>Requester</TableHead>
+                  <TableHead>Size</TableHead>
+                  <TableHead>Payment Locked</TableHead>
+                  <TableHead>Duration</TableHead>
+                  <TableHead>Expires At</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {agreementRequests.map((req) => (
+                  <TableRow key={`req-${req.bucketId}`}>
+                    <TableCell className="font-mono">#{req.bucketId}</TableCell>
+                    <TableCell>
+                      <span className="font-mono">{formatAddress(req.requester)}</span>
+                    </TableCell>
+                    <TableCell>{formatBytes(Number(req.maxBytes))}</TableCell>
+                    <TableCell>{formatTokens(req.paymentLocked)}</TableCell>
+                    <TableCell>{formatDuration(req.duration)}</TableCell>
+                    <TableCell>{formatBlockNumber(req.expiresAt)}</TableCell>
+                    <TableCell>
+                      <Badge variant="warning">Pending</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Active Agreements */}
       <Card>

--- a/user-interfaces/provider/src/state/chain.state.ts
+++ b/user-interfaces/provider/src/state/chain.state.ts
@@ -75,9 +75,12 @@ export async function connect(wsEndpoint?: string): Promise<void> {
   try {
     await connectToChain(ep)
 
-    // Fetch chain properties and configure formatting
+    // Fetch chain properties and configure formatting + SS58 prefix
     const chainProps = await getChainProperties()
     configureFromChain(chainProps)
+    // Dynamically import to avoid circular dependency (wallet → chain-client → chain)
+    const { updateSs58Prefix } = await import('@/state/wallet.state')
+    await updateSs58Prefix(chainProps.ss58Prefix)
     // Store minProviderStake for Registration page
     ;(globalThis as any).__minProviderStake = chainProps.minProviderStake
 

--- a/user-interfaces/provider/src/state/chain.state.ts
+++ b/user-interfaces/provider/src/state/chain.state.ts
@@ -75,14 +75,10 @@ export async function connect(wsEndpoint?: string): Promise<void> {
   try {
     await connectToChain(ep)
 
-    // Fetch chain properties and configure formatting + SS58 prefix
+    // Fetch chain properties and apply all chain-derived config: formatting,
+    // SS58 prefix, and minProviderStake.
     const chainProps = await getChainProperties()
-    configureFromChain(chainProps)
-    // Dynamically import to avoid circular dependency (wallet → chain-client → chain)
-    const { updateSs58Prefix } = await import('@/state/wallet.state')
-    await updateSs58Prefix(chainProps.ss58Prefix)
-    // Store minProviderStake for Registration page
-    ;(globalThis as any).__minProviderStake = chainProps.minProviderStake
+    await configureFromChain(chainProps)
 
     chainInfo$.next({
       name: 'Storage Parachain',

--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -22,6 +22,22 @@ import {
   OnChainChallenge,
   OnChainBucketDetails,
 } from '@/lib/chain-client'
+import { ss58Decode } from '@polkadot-labs/hdkd-helpers'
+
+/** Compare two SS58 addresses by raw public key bytes (prefix-agnostic). */
+function sameAddress(a: string, b: string): boolean {
+  try {
+    const [aBytes] = ss58Decode(a)
+    const [bBytes] = ss58Decode(b)
+    if (aBytes.length !== bBytes.length) return false
+    for (let i = 0; i < aBytes.length; i++) {
+      if (aBytes[i] !== bBytes[i]) return false
+    }
+    return true
+  } catch {
+    return false
+  }
+}
 import { getCurrentBlock } from '@/state/chain.state'
 import { getProviderHttp } from '@/state/network.state'
 
@@ -258,7 +274,7 @@ export async function loadProviderData(address: string): Promise<void> {
     // Phase 2: Fetch bucket details (depends on agreement data for bucket IDs)
     const bucketIds = [...new Set(
       chainAgreements
-        .filter((a) => a.provider === address)
+        .filter((a) => sameAddress(a.provider, address))
         .map((a) => a.bucketId)
     )]
     if (bucketIds.length > 0) {
@@ -267,7 +283,7 @@ export async function loadProviderData(address: string): Promise<void> {
         const currentBlock = getCurrentBlock() || 0
         const agreementsByBucket = new Map<number, typeof chainAgreements[0]>()
         for (const a of chainAgreements) {
-          if (a.provider === address) agreementsByBucket.set(a.bucketId, a)
+          if (sameAddress(a.provider, address)) agreementsByBucket.set(a.bucketId, a)
         }
         bucketDetails$.next(
           chainBucketDetails.map((bd) => {

--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -25,7 +25,7 @@ import {
 import { ss58Decode } from '@polkadot-labs/hdkd-helpers'
 
 /** Compare two SS58 addresses by raw public key bytes (prefix-agnostic). */
-function sameAddress(a: string, b: string): boolean {
+function isSameAddress(a: string, b: string): boolean {
   try {
     const [aBytes] = ss58Decode(a)
     const [bBytes] = ss58Decode(b)

--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -22,22 +22,7 @@ import {
   OnChainChallenge,
   OnChainBucketDetails,
 } from '@/lib/chain-client'
-import { ss58Decode } from '@polkadot-labs/hdkd-helpers'
-
-/** Compare two SS58 addresses by raw public key bytes (prefix-agnostic). */
-function sameAddress(a: string, b: string): boolean {
-  try {
-    const [aBytes] = ss58Decode(a)
-    const [bBytes] = ss58Decode(b)
-    if (aBytes.length !== bBytes.length) return false
-    for (let i = 0; i < aBytes.length; i++) {
-      if (aBytes[i] !== bBytes[i]) return false
-    }
-    return true
-  } catch {
-    return false
-  }
-}
+import { isSameAddress } from '@web3-storage/papi'
 import { getCurrentBlock } from '@/state/chain.state'
 import { getProviderHttp } from '@/state/network.state'
 
@@ -274,7 +259,7 @@ export async function loadProviderData(address: string): Promise<void> {
     // Phase 2: Fetch bucket details (depends on agreement data for bucket IDs)
     const bucketIds = [...new Set(
       chainAgreements
-        .filter((a) => sameAddress(a.provider, address))
+        .filter((a) => isSameAddress(a.provider, address))
         .map((a) => a.bucketId)
     )]
     if (bucketIds.length > 0) {
@@ -283,7 +268,7 @@ export async function loadProviderData(address: string): Promise<void> {
         const currentBlock = getCurrentBlock() || 0
         const agreementsByBucket = new Map<number, typeof chainAgreements[0]>()
         for (const a of chainAgreements) {
-          if (sameAddress(a.provider, address)) agreementsByBucket.set(a.bucketId, a)
+          if (isSameAddress(a.provider, address)) agreementsByBucket.set(a.bucketId, a)
         }
         bucketDetails$.next(
           chainBucketDetails.map((bd) => {

--- a/user-interfaces/provider/src/state/wallet.state.ts
+++ b/user-interfaces/provider/src/state/wallet.state.ts
@@ -27,9 +27,10 @@ import { getPolkadotSigner } from 'polkadot-api/signer'
 import { fromBufferToBase58 } from '@polkadot-api/substrate-bindings'
 import { getAccountBalance, isProviderRegistered } from '@/lib/chain-client'
 
-// Must match the runtime's SS58Prefix (42 = Substrate generic)
-const SS58_PREFIX = 42
-const toSs58 = fromBufferToBase58(SS58_PREFIX)
+// SS58 prefix — defaults to 0 (Polkadot), updated from the runtime
+// System pallet when the chain connects via `updateSs58Prefix()`.
+let ss58Prefix = 0
+let toSs58 = fromBufferToBase58(ss58Prefix)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -83,6 +84,25 @@ const registrationStatusSubject = new BehaviorSubject<Map<string, boolean>>(new 
 const STORAGE_KEY_MODE = 'provider-dashboard-wallet-mode'
 const STORAGE_KEY_EXTENSION = 'provider-dashboard-wallet-extension'
 const STORAGE_KEY_ACCOUNT = 'provider-dashboard-wallet-account'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SS58 prefix update (called after chain connects)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Update the SS58 prefix from the runtime and re-encode any dev accounts.
+ * Called from chain.state after getChainProperties() resolves.
+ */
+export async function updateSs58Prefix(prefix: number): Promise<void> {
+  if (prefix === ss58Prefix) return
+  ss58Prefix = prefix
+  toSs58 = fromBufferToBase58(ss58Prefix)
+
+  // Re-encode dev accounts with the correct prefix if in dev mode
+  if (modeSubject.getValue() === 'dev' && accountsSubject.getValue().length > 0) {
+    await connectDevAccounts()
+  }
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Dev Account Creation (for local development - NO REAL MONEY)

--- a/user-interfaces/provider/src/state/wallet.state.ts
+++ b/user-interfaces/provider/src/state/wallet.state.ts
@@ -24,13 +24,8 @@ import {
   mnemonicToEntropy,
 } from '@polkadot-labs/hdkd-helpers'
 import { getPolkadotSigner } from 'polkadot-api/signer'
-import { fromBufferToBase58 } from '@polkadot-api/substrate-bindings'
+import { getSs58Prefix, isSameAddress, setSs58Prefix, toSs58 } from '@web3-storage/papi'
 import { getAccountBalance, isProviderRegistered } from '@/lib/chain-client'
-
-// SS58 prefix — defaults to 0 (Polkadot), updated from the runtime
-// System pallet when the chain connects via `updateSs58Prefix()`.
-let ss58Prefix = 0
-let toSs58 = fromBufferToBase58(ss58Prefix)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -94,9 +89,8 @@ const STORAGE_KEY_ACCOUNT = 'provider-dashboard-wallet-account'
  * Called from chain.state after getChainProperties() resolves.
  */
 export async function updateSs58Prefix(prefix: number): Promise<void> {
-  if (prefix === ss58Prefix) return
-  ss58Prefix = prefix
-  toSs58 = fromBufferToBase58(ss58Prefix)
+  if (prefix === getSs58Prefix()) return
+  setSs58Prefix(prefix)
 
   // Re-encode dev accounts with the correct prefix if in dev mode
   if (modeSubject.getValue() === 'dev' && accountsSubject.getValue().length > 0) {
@@ -166,8 +160,10 @@ export async function connectDevAccounts(): Promise<void> {
     // default to Alice. Mirrors the extension-mode hydration so a persisted
     // choice survives reload.
     const savedAddress = localStorage.getItem(STORAGE_KEY_ACCOUNT)
+    // Byte-level match: a persisted address may have been encoded under a
+    // different SS58 prefix than the current one.
     const savedAccount = savedAddress
-      ? devAccounts.find((a) => a.address === savedAddress)
+      ? devAccounts.find((a) => isSameAddress(a.address, savedAddress))
       : undefined
     const accountToSelect =
       savedAccount ?? devAccounts.find((a) => a.name?.includes('Alice'))
@@ -209,10 +205,11 @@ export async function connectExtension(extensionName: string): Promise<void> {
     const accounts = extension.getAccounts()
     accountsSubject.next(accounts)
 
-    // Restore previously selected account, or auto-select first
+    // Restore previously selected account, or auto-select first. Byte-level
+    // match: a persisted address may use a different SS58 prefix.
     const savedAddress = localStorage.getItem(STORAGE_KEY_ACCOUNT)
     const savedAccount = savedAddress
-      ? accounts.find((a) => a.address === savedAddress)
+      ? accounts.find((a) => isSameAddress(a.address, savedAddress))
       : undefined
 
     if (!selectedAccountSubject.getValue()) {

--- a/user-interfaces/provider/src/state/wallet.state.ts
+++ b/user-interfaces/provider/src/state/wallet.state.ts
@@ -27,8 +27,8 @@ import { getPolkadotSigner } from 'polkadot-api/signer'
 import { fromBufferToBase58 } from '@polkadot-api/substrate-bindings'
 import { getAccountBalance, isProviderRegistered } from '@/lib/chain-client'
 
-// System parachain `SS58_PREFIX` is 0
-const SS58_PREFIX = 0
+// Must match the runtime's SS58Prefix (42 = Substrate generic)
+const SS58_PREFIX = 42
 const toSs58 = fromBufferToBase58(SS58_PREFIX)
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/user-interfaces/provider/src/utils/format.ts
+++ b/user-interfaces/provider/src/utils/format.ts
@@ -6,18 +6,29 @@ let blockTimeMs = 6000
 let UNIT = 10n ** BigInt(tokenDecimals)
 
 /**
- * Update formatting configuration from chain metadata.
- * Called once after chain connection to replace hardcoded defaults.
+ * Apply chain-derived configuration from chain metadata. Called once after
+ * chain connection to replace hardcoded defaults: number formatting
+ * (decimals/symbol/block time), the SS58 prefix used to encode addresses, and
+ * the minimum provider stake surfaced to the Registration page.
  */
-export function configureFromChain(props: {
+export async function configureFromChain(props: {
   tokenDecimals: number
   tokenSymbol: string
   blockTimeMs: number
+  ss58Prefix: number
+  minProviderStake: bigint
 }) {
   tokenDecimals = props.tokenDecimals
   tokenSymbol = props.tokenSymbol
   blockTimeMs = props.blockTimeMs
   UNIT = 10n ** BigInt(tokenDecimals)
+
+  // Dynamically import to avoid circular dependency (wallet → chain-client → chain)
+  const { updateSs58Prefix } = await import('@/state/wallet.state')
+  await updateSs58Prefix(props.ss58Prefix)
+
+  // Store minProviderStake for Registration page
+  ;(globalThis as any).__minProviderStake = props.minProviderStake
 }
 
 export function getTokenSymbol(): string {

--- a/user-interfaces/shared/network-config/src/index.ts
+++ b/user-interfaces/shared/network-config/src/index.ts
@@ -15,6 +15,7 @@ export {
   loadSelectedNetwork,
   clearSelectedNetwork,
   loadFromUrl,
+  withNetworkHandoff,
 } from './storage'
 
 import { loadFromUrl as _loadFromUrl } from './storage'

--- a/user-interfaces/shared/network-config/src/networks.ts
+++ b/user-interfaces/shared/network-config/src/networks.ts
@@ -65,7 +65,8 @@ export const NETWORK_LIST: NetworkConfig[] = [
   POLKADOT_NETWORK,
 ]
 
-export const DEFAULT_NETWORK_ID: NetworkId = 'previewnet'
+export const DEFAULT_NETWORK_ID: NetworkId =
+  import.meta.env?.DEV ? 'local' : 'previewnet'
 
 export function createCustomNetwork(parachainWs: string, providerHttp: string): NetworkConfig {
   return {

--- a/user-interfaces/shared/network-config/src/storage.ts
+++ b/user-interfaces/shared/network-config/src/storage.ts
@@ -55,6 +55,25 @@ export function clearSelectedNetwork(): void {
 }
 
 /**
+ * Append the current network selection to a URL as query params, mirroring
+ * what `loadFromUrl()` consumes on the receiving side. Used by the apps'
+ * "back to home" link so the landing page reflects the in-app selection even
+ * in dev, where each app runs on its own origin and localStorage isn't shared.
+ */
+export function withNetworkHandoff(
+  base: string,
+  network: { id: NetworkId; parachainWs?: string; providerHttp?: string },
+): string {
+  const params = new URLSearchParams()
+  params.set('network', network.id)
+  if (network.id === 'custom') {
+    if (network.parachainWs) params.set('parachainWs', network.parachainWs)
+    if (network.providerHttp) params.set('providerHttp', network.providerHttp)
+  }
+  return base + (base.includes('?') ? '&' : '?') + params.toString()
+}
+
+/**
  * Pick up a network selection passed via URL (e.g. landing-page handoff).
  * Reads ?network=, optionally ?parachainWs=&providerHttp= for custom, persists
  * via saveSelectedNetwork(), then strips the params from the URL so a refresh

--- a/user-interfaces/shared/network-config/tsconfig.json
+++ b/user-interfaces/shared/network-config/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "noEmit": true,
     "isolatedModules": true,
+    "types": ["vite/client"],
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true

--- a/user-interfaces/shared/papi/package.json
+++ b/user-interfaces/shared/papi/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "Single source of truth for the parachain runtime descriptors. Owns the only tracked metadata snapshot in the repo. The internally-named @polkadot-api/descriptors package under .papi/descriptors is what the UIs consume via workspace:*.",
   "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "papi:install": "papi generate",
     "papi:generate": "papi add -w ws://127.0.0.1:2222 parachain && papi generate"
@@ -12,6 +16,7 @@
     "@polkadot-api/cli": "^0.20.4"
   },
   "dependencies": {
-    "@polkadot-api/descriptors": "file:.papi/descriptors"
+    "@polkadot-api/descriptors": "file:.papi/descriptors",
+    "@polkadot-labs/hdkd-helpers": "^0.0.30"
   }
 }

--- a/user-interfaces/shared/papi/src/index.ts
+++ b/user-interfaces/shared/papi/src/index.ts
@@ -2,13 +2,39 @@
  * Shared PAPI utilities used across all UIs.
  */
 
-import { ss58Decode } from '@polkadot-labs/hdkd-helpers'
+import { ss58Address, ss58Decode } from '@polkadot-labs/hdkd-helpers'
 import { multiaddrToUri } from "@multiformats/multiaddr-to-uri";
 import { parachain } from "@polkadot-api/descriptors";
 import type { TypedApi } from "polkadot-api";
 
 /** Typed parachain API, shared by every UI that talks to the chain. */
 export type ParachainApi = TypedApi<typeof parachain>;
+
+/**
+ * SS58 address prefix used to encode public keys for display.
+ *
+ * Defaults to 0 (Polkadot `1…` style). The prefix is a per-network property, so
+ * a UI that connects to a chain refines it from the runtime on connect via
+ * `setSs58Prefix(api.constants.System.SS58Prefix())`. Every address *comparison*
+ * goes through `isSameAddress` below (raw bytes), so this value only affects how
+ * addresses are rendered — never matching correctness.
+ */
+let ss58Prefix = 0
+
+/** Current SS58 prefix used by `toSs58`. */
+export function getSs58Prefix(): number {
+  return ss58Prefix
+}
+
+/** Set the SS58 prefix, typically from the connected runtime's `SS58Prefix`. */
+export function setSs58Prefix(prefix: number): void {
+  ss58Prefix = prefix
+}
+
+/** Encode a raw public key as an SS58 address using the current prefix. */
+export function toSs58(publicKey: Uint8Array): string {
+  return ss58Address(publicKey, ss58Prefix)
+}
 
 /** Compare two SS58 addresses by raw public key bytes (prefix-agnostic). */
 export function isSameAddress(a: string, b: string): boolean {

--- a/user-interfaces/shared/papi/src/index.ts
+++ b/user-interfaces/shared/papi/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared PAPI utilities used across all UIs.
+ */
+
+import { ss58Decode } from '@polkadot-labs/hdkd-helpers'
+
+/** Compare two SS58 addresses by raw public key bytes (prefix-agnostic). */
+export function isSameAddress(a: string, b: string): boolean {
+  try {
+    const [aBytes] = ss58Decode(a)
+    const [bBytes] = ss58Decode(b)
+    if (aBytes.length !== bBytes.length) return false
+    for (let i = 0; i < aBytes.length; i++) {
+      if (aBytes[i] !== bBytes[i]) return false
+    }
+    return true
+  } catch {
+    return false
+  }
+}

--- a/user-interfaces/shared/test-helpers/package.json
+++ b/user-interfaces/shared/test-helpers/package.json
@@ -13,6 +13,7 @@
     "@polkadot-api/substrate-bindings": "^0.20.1",
     "@polkadot-labs/hdkd": "^0.0.28",
     "@polkadot-labs/hdkd-helpers": "^0.0.30",
+    "@web3-storage/papi": "workspace:*",
     "polkadot-api": "^2.1.0"
   },
   "devDependencies": {

--- a/user-interfaces/shared/test-helpers/src/registration.ts
+++ b/user-interfaces/shared/test-helpers/src/registration.ts
@@ -7,8 +7,8 @@ import { Alice, devSigners, type DevAccountName, type DevSigner } from "./signer
  * Hex-encode an account's raw 32-byte public key. PAPI returns
  * `getEntries()` keys in the chain's SS58 prefix (42 on the local
  * runtime, 0 on paseo) while `signers.ts` builds dev-signer addresses
- * with prefix 0 — string equality then fails on local. Compare via raw
- * bytes so the helper works against either runtime.
+ * with the shared default prefix (42) — string equality then fails on
+ * paseo. Compare via raw bytes so the helper works against either runtime.
  */
 function publicKeyHex(address: string): string {
   const [bytes] = ss58Decode(address);

--- a/user-interfaces/shared/test-helpers/src/signers.ts
+++ b/user-interfaces/shared/test-helpers/src/signers.ts
@@ -5,11 +5,7 @@ import {
   mnemonicToEntropy,
 } from "@polkadot-labs/hdkd-helpers";
 import { getPolkadotSigner, type PolkadotSigner } from "polkadot-api/signer";
-import { fromBufferToBase58 } from "@polkadot-api/substrate-bindings";
-
-// System parachain `SS58_PREFIX` is 0
-const SS58_PREFIX = 0;
-const toSs58 = fromBufferToBase58(SS58_PREFIX);
+import { toSs58 } from "@web3-storage/papi";
 
 const entropy = mnemonicToEntropy(DEV_PHRASE);
 const miniSecret = entropyToMiniSecret(entropy);


### PR DESCRIPTION
## Summary

- **Fix default network in dev mode** — default to `local` when running `vite dev`, `previewnet` in production (#114)
- **Fix SS58 address mismatch** — provider dashboard used SS58 prefix 0 while the runtime uses prefix 42, causing all agreements/requests/challenges/buckets to be filtered out. Added byte-level address comparison via `ss58Decode` (#115)
- **Add pending agreement requests UI** — the Agreements page now shows a "Pending Requests" section with request details (#116)
- **Fix drive UI account switch** — switching accounts now clears stale state and reloads drives for the new user (#117)
- **Fix NewFolderDialog UX and PAPI Binary decoding** — async loading state for folder creation + handle PAPI Binary `.asText()` in drive name decoding (#118)
- **Fix S3 bucket creation UX** — replace blocking spinner with status cards that track progress in the background (#119)

## Test plan

- [x] Start local chain + provider, open provider dashboard — should default to "Local Development" network
- [x] Connect as Alice in provider dashboard — agreements, buckets, challenges should be visible
- [x] Create a storage request — should appear in "Pending Requests" section on Agreements page
- [x] Open drive UI, switch between Alice/Bob — drives should refresh and show the correct user's data
- [x] Create a new folder in drive UI — dialog should show loading spinner during creation
- [x] Create an S3 bucket in console UI — form should close immediately and show a status card tracking progress

## Status Card in S3 Console

<img width="1240" height="517" alt="Screenshot 2026-06-02 at 20 20 33" src="https://github.com/user-attachments/assets/f0766abb-8cfa-45ff-9b2e-5ab50a3d4eff" />

<img width="1239" height="625" alt="Screenshot 2026-06-02 at 20 20 47" src="https://github.com/user-attachments/assets/f098774a-f4f9-4f70-9e08-2c0fc33316fa" />

<img width="1240" height="607" alt="Screenshot 2026-06-02 at 20 21 15" src="https://github.com/user-attachments/assets/546efe65-9875-412c-89dc-53d1b06e246b" />

<img width="1242" height="627" alt="Screenshot 2026-06-02 at 20 21 29" src="https://github.com/user-attachments/assets/e6e15dc1-cbd2-45d6-ac54-f4a4ece2d2c3" />

## Pending and Accepted Agreements in Provider Console
<img width="1311" height="738" alt="Screenshot 2026-06-02 at 20 22 51" src="https://github.com/user-attachments/assets/e3ed5dfb-0df9-4db9-9e47-a24328af320e" />

<img width="1345" height="591" alt="Screenshot 2026-06-02 at 20 23 08" src="https://github.com/user-attachments/assets/ad9e7c26-f66b-4e68-ace8-863f2b902acd" />

## Drive working in Drive Console
<img width="1452" height="808" alt="Screenshot 2026-06-02 at 20 23 30" src="https://github.com/user-attachments/assets/caf23eec-5aac-498a-bd09-4faaee65a7a9" />

## Drive Creation Statuses
<img width="608" height="567" alt="Screenshot 2026-06-02 at 20 27 13" src="https://github.com/user-attachments/assets/01b08338-e6f1-4bed-89da-049e4e4187c1" />
<img width="574" height="531" alt="Screenshot 2026-06-02 at 20 27 50" src="https://github.com/user-attachments/assets/f559a1dc-798f-452a-bc7e-108e4e5d1205" />
<img width="584" height="589" alt="Screenshot 2026-06-02 at 20 28 17" src="https://github.com/user-attachments/assets/7040a204-862b-4367-9b22-0e48a9dd6e41" />
<img width="1489" height="814" alt="Screenshot 2026-06-02 at 20 28 31" src="https://github.com/user-attachments/assets/f6edf0ce-6370-4e57-be4b-a02cea4a07b6" />

