### PR TITLE
test(pallet): add tests for challenges, checkpoints, replicas, events, and runtime API

### DIFF
--- a/pallet/src/mock.rs
+++ b/pallet/src/mock.rs
@@ -127,7 +127,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 /// Build test externalities with custom balances.
-#[allow(dead_code)]
 pub fn new_test_ext_with_balances(balances: Vec<(u64, u64)>) -> sp_io::TestExternalities {
     let mut t = frame_system::GenesisConfig::<Test>::default()
         .build_storage()
@@ -143,29 +142,25 @@ pub fn new_test_ext_with_balances(balances: Vec<(u64, u64)>) -> sp_io::TestExter
     t.into()
 }
 
-/// Run to a specific block number.
-///
-/// **WARNING**: This only calls `System` hooks, NOT `StorageProvider::on_finalize`.
-/// This means challenge expirations and slashing will NOT be processed automatically.
-/// If your test needs to trigger challenge timeout slashing, call the pallet hook
-/// manually: `<StorageProvider as Hooks<u64>>::on_finalize(block_number);`
-#[allow(dead_code)]
+/// Run to a specific block number, calling both System and StorageProvider hooks.
 pub fn run_to_block(n: u64) {
     while System::block_number() < n {
-        <System as Hooks<u64>>::on_finalize(System::block_number());
-        System::set_block_number(System::block_number() + 1);
-        <System as Hooks<u64>>::on_initialize(System::block_number());
+        let current = System::block_number();
+        if current > 1 {
+            <StorageProvider as Hooks<u64>>::on_finalize(current);
+        }
+        <System as Hooks<u64>>::on_finalize(current);
+        System::set_block_number(current + 1);
+        <System as Hooks<u64>>::on_initialize(current + 1);
     }
 }
 
 /// Helper: create a test public key (32 bytes).
-#[allow(dead_code)]
 pub fn test_public_key() -> frame_support::BoundedVec<u8, frame_support::traits::ConstU32<64>> {
     vec![1u8; 32].try_into().unwrap()
 }
 
 /// Helper: register a provider with default settings and given stake.
-#[allow(dead_code)]
 pub fn register_provider(who: u64, stake: u64) {
     use frame_support::assert_ok;
     let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
@@ -178,7 +173,6 @@ pub fn register_provider(who: u64, stake: u64) {
 }
 
 /// Helper: register a provider with custom settings.
-#[allow(dead_code)]
 pub fn register_provider_with_settings(
     who: u64,
     stake: u64,
@@ -193,7 +187,6 @@ pub fn register_provider_with_settings(
 }
 
 /// Helper: create a bucket, request + accept a Primary agreement. Returns bucket_id.
-#[allow(dead_code)]
 pub fn setup_agreement(provider: u64, client: u64, max_bytes: u64, duration: u64) -> u64 {
     use frame_support::assert_ok;
     assert_ok!(StorageProvider::create_bucket(

--- a/pallet/src/mock.rs
+++ b/pallet/src/mock.rs
@@ -144,6 +144,11 @@ pub fn new_test_ext_with_balances(balances: Vec<(u64, u64)>) -> sp_io::TestExter
 }
 
 /// Run to a specific block number.
+///
+/// **WARNING**: This only calls `System` hooks, NOT `StorageProvider::on_finalize`.
+/// This means challenge expirations and slashing will NOT be processed automatically.
+/// If your test needs to trigger challenge timeout slashing, call the pallet hook
+/// manually: `<StorageProvider as Hooks<u64>>::on_finalize(block_number);`
 #[allow(dead_code)]
 pub fn run_to_block(n: u64) {
     while System::block_number() < n {

--- a/pallet/src/tests/challenge.rs
+++ b/pallet/src/tests/challenge.rs
@@ -268,3 +268,397 @@ fn challenge_slashes_provider_on_timeout() {
         assert_eq!(provider.stats.challenges_failed, 1);
     });
 }
+
+#[test]
+fn respond_to_challenge_superseded_fails_leaf_beyond_canonical() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        // Challenge at leaf_index 10 against snapshot with leaf_count=10, start_seq=0
+        // challenged_seq = 0 + 10 = 10, canonical_end = 0 + 10 = 10
+        // 10 < 10 is false → LeafBeyondCanonical
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            10, // leaf_index at boundary
+            0,
+        ));
+
+        let challenge_id = ChallengeId {
+            deadline: 101,
+            index: 0,
+        };
+
+        assert_noop!(
+            StorageProvider::respond_to_challenge(
+                RuntimeOrigin::signed(2),
+                challenge_id,
+                crate::ChallengeResponse::Superseded,
+            ),
+            Error::<Test>::LeafBeyondCanonical
+        );
+    });
+}
+
+#[test]
+fn respond_to_challenge_superseded_cost_split_block_1() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        let challenger_balance_before = Balances::free_balance(3);
+        let provider_stake_before = Providers::<Test>::get(2).unwrap().stake;
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let challenge_id = ChallengeId {
+            deadline: 101,
+            index: 0,
+        };
+
+        // Respond at block 2 → response_time = 2 - (101-100) = 2 - 1 = 1
+        run_to_block(2);
+
+        assert_ok!(StorageProvider::respond_to_challenge(
+            RuntimeOrigin::signed(2),
+            challenge_id,
+            crate::ChallengeResponse::Superseded,
+        ));
+
+        // Block 1: challenger 90%, provider 10%
+        // deposit = 100, challenger_cost = 90, provider_cost = 10
+        // Challenger gets unreserved (100 - 90) = 10 back
+        assert_eq!(Balances::free_balance(3), challenger_balance_before - 90);
+
+        // Provider stake decreased by 10
+        let provider_stake_after = Providers::<Test>::get(2).unwrap().stake;
+        assert_eq!(provider_stake_after, provider_stake_before - 10);
+    });
+}
+
+#[test]
+fn respond_to_challenge_superseded_cost_split_block_5() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        let challenger_balance_before = Balances::free_balance(3);
+        let provider_stake_before = Providers::<Test>::get(2).unwrap().stake;
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let challenge_id = ChallengeId {
+            deadline: 101,
+            index: 0,
+        };
+
+        // Respond at block 6 → response_time = 6 - 1 = 5
+        // Blocks 2-5: challenger 80%, provider 20%
+        run_to_block(6);
+
+        assert_ok!(StorageProvider::respond_to_challenge(
+            RuntimeOrigin::signed(2),
+            challenge_id,
+            crate::ChallengeResponse::Superseded,
+        ));
+
+        // challenger_cost = 80, provider_cost = 20
+        assert_eq!(Balances::free_balance(3), challenger_balance_before - 80);
+        let provider_stake_after = Providers::<Test>::get(2).unwrap().stake;
+        assert_eq!(provider_stake_after, provider_stake_before - 20);
+    });
+}
+
+#[test]
+fn respond_to_challenge_superseded_cost_split_block_24() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        let challenger_balance_before = Balances::free_balance(3);
+        let provider_stake_before = Providers::<Test>::get(2).unwrap().stake;
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let challenge_id = ChallengeId {
+            deadline: 101,
+            index: 0,
+        };
+
+        // Respond at block 25 → response_time = 25 - 1 = 24
+        // Blocks 6-24: challenger 70%, provider 30%
+        run_to_block(25);
+
+        assert_ok!(StorageProvider::respond_to_challenge(
+            RuntimeOrigin::signed(2),
+            challenge_id,
+            crate::ChallengeResponse::Superseded,
+        ));
+
+        // challenger_cost = 70, provider_cost = 30
+        assert_eq!(Balances::free_balance(3), challenger_balance_before - 70);
+        let provider_stake_after = Providers::<Test>::get(2).unwrap().stake;
+        assert_eq!(provider_stake_after, provider_stake_before - 30);
+    });
+}
+
+#[test]
+fn respond_to_challenge_superseded_cost_split_block_95() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        let challenger_balance_before = Balances::free_balance(3);
+        let provider_stake_before = Providers::<Test>::get(2).unwrap().stake;
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let challenge_id = ChallengeId {
+            deadline: 101,
+            index: 0,
+        };
+
+        // Respond at block 96 → response_time = 96 - 1 = 95
+        // Blocks 25-95: challenger 60%, provider 40%
+        run_to_block(96);
+
+        assert_ok!(StorageProvider::respond_to_challenge(
+            RuntimeOrigin::signed(2),
+            challenge_id,
+            crate::ChallengeResponse::Superseded,
+        ));
+
+        // challenger_cost = 60, provider_cost = 40
+        assert_eq!(Balances::free_balance(3), challenger_balance_before - 60);
+        let provider_stake_after = Providers::<Test>::get(2).unwrap().stake;
+        assert_eq!(provider_stake_after, provider_stake_before - 40);
+    });
+}
+
+#[test]
+fn respond_to_challenge_superseded_cost_split_block_96_plus() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        let challenger_balance_before = Balances::free_balance(3);
+        let provider_stake_before = Providers::<Test>::get(2).unwrap().stake;
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let challenge_id = ChallengeId {
+            deadline: 101,
+            index: 0,
+        };
+
+        // Respond at block 100 → response_time = 100 - 1 = 99
+        // Blocks 96+: challenger 50%, provider 50%
+        run_to_block(100);
+
+        assert_ok!(StorageProvider::respond_to_challenge(
+            RuntimeOrigin::signed(2),
+            challenge_id,
+            crate::ChallengeResponse::Superseded,
+        ));
+
+        // challenger_cost = 50, provider_cost = 50
+        assert_eq!(Balances::free_balance(3), challenger_balance_before - 50);
+        let provider_stake_after = Providers::<Test>::get(2).unwrap().stake;
+        assert_eq!(provider_stake_after, provider_stake_before - 50);
+    });
+}
+
+#[test]
+fn challenge_slashes_multiple_challenges_on_finalize() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+
+        // Setup two providers with agreements
+        register_provider(2, 200);
+        register_provider(3, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 200);
+
+        // Add second provider to same bucket
+        assert_ok!(StorageProvider::request_primary_agreement(
+            RuntimeOrigin::signed(1),
+            bucket_id,
+            3,
+            50,
+            200,
+            10000,
+        ));
+        assert_ok!(StorageProvider::accept_agreement(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+        ));
+
+        // Insert snapshot where both providers signed
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                bucket.snapshot = Some(BucketSnapshot {
+                    mmr_root: H256::repeat_byte(0xAB),
+                    start_seq: 0,
+                    leaf_count: 10,
+                    checkpoint_block: 1,
+                    primary_signers: vec![0x03], // bits 0 and 1 set
+                });
+            }
+        });
+
+        // Challenge both providers — both expire at same deadline
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(4),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(5),
+            bucket_id,
+            3,
+            0,
+            0,
+        ));
+
+        // Both challenges at deadline 101
+        let challenges = Challenges::<Test>::get(101).unwrap();
+        assert_eq!(challenges.len(), 2);
+
+        // Advance to deadline and finalize
+        run_to_block(101);
+        <StorageProvider as frame_support::traits::Hooks<u64>>::on_finalize(101);
+
+        // Both providers should be slashed
+        let provider2 = Providers::<Test>::get(2).unwrap();
+        assert_eq!(provider2.stake, 0);
+        assert_eq!(provider2.stats.challenges_failed, 1);
+
+        let provider3 = Providers::<Test>::get(3).unwrap();
+        assert_eq!(provider3.stake, 0);
+        assert_eq!(provider3.stats.challenges_failed, 1);
+
+        // Challenges should be removed
+        assert!(Challenges::<Test>::get(101).is_none());
+    });
+}
+
+#[test]
+fn challenge_slashes_emits_event_and_rewards_challenger() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        let provider_stake = Providers::<Test>::get(2).unwrap().stake;
+        let challenger_balance_before = Balances::free_balance(3);
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        // Challenger deposit (100) was reserved
+        assert_eq!(Balances::free_balance(3), challenger_balance_before - 100);
+
+        run_to_block(101);
+        <StorageProvider as frame_support::traits::Hooks<u64>>::on_finalize(101);
+
+        // Challenger gets deposit back + 10% of slashed amount
+        let challenger_reward = provider_stake / 10;
+        assert_eq!(
+            Balances::free_balance(3),
+            challenger_balance_before + challenger_reward
+        );
+
+        // Verify ChallengeSlashed event
+        let expected_event = RuntimeEvent::StorageProvider(crate::Event::ChallengeSlashed {
+            challenge_id: ChallengeId {
+                deadline: 101,
+                index: 0,
+            },
+            provider: 2,
+            slashed_amount: provider_stake,
+            challenger_reward,
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected_event));
+    });
+}
+
+#[test]
+fn respond_to_challenge_superseded_emits_defended_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let challenge_id = ChallengeId {
+            deadline: 101,
+            index: 0,
+        };
+
+        // Respond at block 2 → response_time = 1
+        run_to_block(2);
+
+        assert_ok!(StorageProvider::respond_to_challenge(
+            RuntimeOrigin::signed(2),
+            challenge_id,
+            crate::ChallengeResponse::Superseded,
+        ));
+
+        // Verify ChallengeDefended event
+        let expected_event = RuntimeEvent::StorageProvider(crate::Event::ChallengeDefended {
+            challenge_id,
+            provider: 2,
+            response_time_blocks: 1,
+            challenger_cost: 90,
+            provider_cost: 10,
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected_event));
+    });
+}

--- a/pallet/src/tests/challenge.rs
+++ b/pallet/src/tests/challenge.rs
@@ -175,40 +175,6 @@ fn respond_to_challenge_fails_not_provider() {
 }
 
 #[test]
-fn respond_to_challenge_fails_expired() {
-    new_test_ext().execute_with(|| {
-        frame_system::Pallet::<Test>::set_block_number(1);
-        let bucket_id = setup_with_snapshot(2, 1);
-
-        assert_ok!(StorageProvider::challenge_checkpoint(
-            RuntimeOrigin::signed(3),
-            bucket_id,
-            2,
-            0,
-            0,
-        ));
-
-        let challenge_id = ChallengeId {
-            deadline: 101,
-            index: 0,
-        };
-
-        // Advance past deadline (run_to_block only calls System hooks,
-        // not the pallet's on_finalize, so the challenge still exists)
-        run_to_block(102);
-
-        assert_noop!(
-            StorageProvider::respond_to_challenge(
-                RuntimeOrigin::signed(2),
-                challenge_id,
-                crate::ChallengeResponse::Superseded,
-            ),
-            Error::<Test>::ChallengeExpired
-        );
-    });
-}
-
-#[test]
 fn respond_to_challenge_superseded_works() {
     new_test_ext().execute_with(|| {
         frame_system::Pallet::<Test>::set_block_number(1);
@@ -258,9 +224,8 @@ fn challenge_slashes_provider_on_timeout() {
         ));
 
         // Challenge deadline = block 1 + ChallengeTimeout(100) = 101
-        // run_to_block only calls System hooks, so manually call pallet on_finalize
-        run_to_block(101);
-        <StorageProvider as frame_support::traits::Hooks<u64>>::on_finalize(101);
+        // run_to_block(102) finalises block 101, triggering pallet on_finalize
+        run_to_block(102);
 
         // Provider should be slashed
         let provider = Providers::<Test>::get(2).unwrap();
@@ -557,9 +522,8 @@ fn challenge_slashes_multiple_challenges_on_finalize() {
         let challenges = Challenges::<Test>::get(101).unwrap();
         assert_eq!(challenges.len(), 2);
 
-        // Advance to deadline and finalize
-        run_to_block(101);
-        <StorageProvider as frame_support::traits::Hooks<u64>>::on_finalize(101);
+        // Advance past deadline — run_to_block(102) finalises block 101
+        run_to_block(102);
 
         // Both providers should be slashed
         let provider2 = Providers::<Test>::get(2).unwrap();
@@ -595,8 +559,8 @@ fn challenge_slashes_emits_event_and_rewards_challenger() {
         // Challenger deposit (100) was reserved
         assert_eq!(Balances::free_balance(3), challenger_balance_before - 100);
 
-        run_to_block(101);
-        <StorageProvider as frame_support::traits::Hooks<u64>>::on_finalize(101);
+        // run_to_block(102) finalises block 101, triggering slash
+        run_to_block(102);
 
         // Challenger gets deposit back + 10% of slashed amount
         let challenger_reward = provider_stake / 10;

--- a/pallet/src/tests/checkpoint.rs
+++ b/pallet/src/tests/checkpoint.rs
@@ -1,6 +1,77 @@
 use super::*;
-use sp_core::H256;
+use codec::Encode;
+use sp_core::{sr25519, Pair, H256};
 use storage_primitives::BucketSnapshot;
+
+/// Register a provider using a real Sr25519 keypair so signatures can be verified on-chain.
+/// Returns the keypair for later use in signing.
+fn register_provider_with_keypair(who: u64, stake: u64) -> sr25519::Pair {
+    use frame_support::assert_ok;
+    let (pair, _) = sr25519::Pair::generate();
+    let public_key: frame_support::BoundedVec<u8, frame_support::traits::ConstU32<64>> =
+        pair.public().0.to_vec().try_into().unwrap();
+    let multiaddr = b"/ip4/127.0.0.1/tcp/3000".to_vec();
+    assert_ok!(StorageProvider::register_provider(
+        RuntimeOrigin::signed(who),
+        multiaddr.try_into().unwrap(),
+        public_key,
+        stake,
+    ));
+    pair
+}
+
+/// Create a signed checkpoint proposal for use in provider_checkpoint calls.
+fn sign_checkpoint_proposal(
+    pair: &sr25519::Pair,
+    signer_account: u64,
+    bucket_id: u64,
+    mmr_root: H256,
+    start_seq: u64,
+    leaf_count: u64,
+    window: u64,
+) -> (u64, sp_runtime::MultiSignature) {
+    let proposal = storage_primitives::CheckpointProposal::new(
+        bucket_id, mmr_root, start_seq, leaf_count, window,
+    );
+    let encoded = proposal.encode();
+    let signature = pair.sign(&encoded);
+    (
+        signer_account,
+        sp_runtime::MultiSignature::Sr25519(signature),
+    )
+}
+
+/// Setup agreement with a keypair-registered provider. Returns (bucket_id, keypair).
+fn setup_agreement_with_keypair(
+    provider: u64,
+    client: u64,
+    max_bytes: u64,
+    duration: u64,
+) -> (u64, sr25519::Pair) {
+    let pair = register_provider_with_keypair(provider, 200);
+    let bucket_id = {
+        use frame_support::assert_ok;
+        assert_ok!(StorageProvider::create_bucket(
+            RuntimeOrigin::signed(client),
+            1
+        ));
+        let bucket_id = crate::NextBucketId::<Test>::get() - 1;
+        assert_ok!(StorageProvider::request_primary_agreement(
+            RuntimeOrigin::signed(client),
+            bucket_id,
+            provider,
+            max_bytes,
+            duration,
+            max_bytes * duration,
+        ));
+        assert_ok!(StorageProvider::accept_agreement(
+            RuntimeOrigin::signed(provider),
+            bucket_id,
+        ));
+        bucket_id
+    };
+    (bucket_id, pair)
+}
 
 /// Insert a snapshot directly into storage for testing checkpoint-related extrinsics.
 #[allow(dead_code)]
@@ -327,6 +398,371 @@ fn provider_checkpoint_fails_wrong_window() {
                 Default::default(),
             ),
             Error::<Test>::InvalidCheckpointWindow
+        );
+    });
+}
+
+#[test]
+fn provider_checkpoint_leader_within_grace_period() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair) = setup_agreement_with_keypair(2, 1, 50, 500);
+
+        // With only 1 provider, leader_idx = hash % 1 = 0, so provider 2 is always leader
+        // Default interval=10, grace=5. Window 0 starts at block 0.
+        // At block 3 we're within grace period (block <= 0 + 5).
+        run_to_block(3);
+
+        let sig = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xAA), 0, 10, 0);
+
+        assert_ok!(StorageProvider::provider_checkpoint(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0, // window 0
+            vec![sig].try_into().unwrap(),
+        ));
+
+        let bucket = Buckets::<Test>::get(bucket_id).unwrap();
+        let snapshot = bucket.snapshot.unwrap();
+        assert_eq!(snapshot.mmr_root, H256::repeat_byte(0xAA));
+        assert_eq!(snapshot.leaf_count, 10);
+        assert_eq!(LastCheckpointWindow::<Test>::get(bucket_id), Some(0));
+    });
+}
+
+#[test]
+fn provider_checkpoint_non_leader_rejected_during_grace() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair2) = setup_agreement_with_keypair(2, 1, 50, 500);
+        let pair3 = register_provider_with_keypair(3, 200);
+
+        // Add second provider
+        assert_ok!(StorageProvider::request_primary_agreement(
+            RuntimeOrigin::signed(1),
+            bucket_id,
+            3,
+            50,
+            500,
+            25000,
+        ));
+        assert_ok!(StorageProvider::accept_agreement(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+        ));
+
+        // Within grace period, only leader can submit.
+        // Determine the leader deterministically and only try the non-leader.
+        run_to_block(3);
+
+        let bucket = Buckets::<Test>::get(bucket_id).unwrap();
+        let num_providers = bucket.primary_providers.len() as u32;
+        // Replicate deterministic leader election: blake2_256(bucket_id || window) % num_providers
+        let mut data = [0u8; 16];
+        data[..8].copy_from_slice(&bucket_id.to_le_bytes());
+        data[8..].copy_from_slice(&0u64.to_le_bytes()); // window = 0
+        let hash = sp_io::hashing::blake2_256(&data);
+        let seed = u32::from_le_bytes([hash[0], hash[1], hash[2], hash[3]]);
+        let leader_idx = (seed % num_providers) as usize;
+        let leader_account = bucket.primary_providers[leader_idx];
+
+        // Try submitting as the non-leader — should fail with NotCheckpointLeader
+        let (non_leader_account, non_leader_pair) = if leader_account == 2 {
+            (3u64, &pair3)
+        } else {
+            (2u64, &pair2)
+        };
+
+        let sig = sign_checkpoint_proposal(
+            non_leader_pair,
+            non_leader_account,
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0,
+        );
+
+        assert_noop!(
+            StorageProvider::provider_checkpoint(
+                RuntimeOrigin::signed(non_leader_account),
+                bucket_id,
+                H256::repeat_byte(0xAA),
+                0,
+                10,
+                0,
+                vec![sig].try_into().unwrap(),
+            ),
+            Error::<Test>::NotCheckpointLeader
+        );
+    });
+}
+
+#[test]
+fn provider_checkpoint_fallback_after_grace() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair2) = setup_agreement_with_keypair(2, 1, 50, 500);
+        let _pair3 = register_provider_with_keypair(3, 200);
+
+        // Add second provider
+        assert_ok!(StorageProvider::request_primary_agreement(
+            RuntimeOrigin::signed(1),
+            bucket_id,
+            3,
+            50,
+            500,
+            25000,
+        ));
+        assert_ok!(StorageProvider::accept_agreement(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+        ));
+
+        // After grace period (block > window_start + grace = 0 + 5 = 5)
+        // Any primary provider can submit (fallback)
+        run_to_block(6);
+
+        let sig2 =
+            sign_checkpoint_proposal(&pair2, 2, bucket_id, H256::repeat_byte(0xAA), 0, 10, 0);
+
+        // After grace, any primary provider can submit — provider 2 must succeed
+        assert_ok!(StorageProvider::provider_checkpoint(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0,
+            vec![sig2].try_into().unwrap(),
+        ));
+        let bucket = Buckets::<Test>::get(bucket_id).unwrap();
+        assert_eq!(bucket.snapshot.unwrap().mmr_root, H256::repeat_byte(0xAA));
+    });
+}
+
+#[test]
+fn provider_checkpoint_already_submitted() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair) = setup_agreement_with_keypair(2, 1, 50, 500);
+
+        let sig = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xAA), 0, 10, 0);
+
+        // Submit checkpoint for window 0
+        assert_ok!(StorageProvider::provider_checkpoint(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0,
+            vec![sig].try_into().unwrap(),
+        ));
+
+        let sig2 = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xBB), 0, 20, 0);
+
+        // Try to submit again for window 0
+        assert_noop!(
+            StorageProvider::provider_checkpoint(
+                RuntimeOrigin::signed(2),
+                bucket_id,
+                H256::repeat_byte(0xBB),
+                0,
+                20,
+                0,
+                vec![sig2].try_into().unwrap(),
+            ),
+            Error::<Test>::CheckpointAlreadySubmitted
+        );
+    });
+}
+
+#[test]
+fn provider_checkpoint_frozen_constraint() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair) = setup_agreement_with_keypair(2, 1, 50, 500);
+
+        // Set frozen_start_seq on the bucket
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                bucket.frozen_start_seq = Some(5);
+            }
+        });
+
+        let sig = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xAA), 3, 10, 0);
+
+        // Try to submit with start_seq < frozen_start_seq
+        assert_noop!(
+            StorageProvider::provider_checkpoint(
+                RuntimeOrigin::signed(2),
+                bucket_id,
+                H256::repeat_byte(0xAA),
+                3, // start_seq < frozen_start_seq(5)
+                10,
+                0,
+                vec![sig].try_into().unwrap(),
+            ),
+            Error::<Test>::SnapshotViolatesFrozen
+        );
+    });
+}
+
+#[test]
+fn provider_checkpoint_reward_from_pool() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair) = setup_agreement_with_keypair(2, 1, 50, 500);
+
+        // Fund the checkpoint pool
+        assert_ok!(StorageProvider::fund_checkpoint_pool(
+            RuntimeOrigin::signed(1),
+            bucket_id,
+            500,
+        ));
+
+        let pool_before = CheckpointPool::<Test>::get(bucket_id);
+        assert_eq!(pool_before, 500);
+
+        let sig = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xAA), 0, 10, 0);
+
+        // Submit checkpoint
+        assert_ok!(StorageProvider::provider_checkpoint(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0,
+            vec![sig].try_into().unwrap(),
+        ));
+
+        // Pool should decrease by CheckpointReward (10)
+        assert_eq!(CheckpointPool::<Test>::get(bucket_id), 500 - 10);
+
+        // Reward should be stored in CheckpointRewards
+        assert_eq!(CheckpointRewards::<Test>::get(2u64, bucket_id), 10);
+    });
+}
+
+#[test]
+fn provider_checkpoint_no_reward_empty_pool() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair) = setup_agreement_with_keypair(2, 1, 50, 500);
+
+        let sig = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xAA), 0, 10, 0);
+
+        // Don't fund pool — should still succeed but reward = 0
+        assert_ok!(StorageProvider::provider_checkpoint(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0,
+            vec![sig].try_into().unwrap(),
+        ));
+
+        // No reward accumulated
+        assert_eq!(CheckpointRewards::<Test>::get(2u64, bucket_id), 0);
+    });
+}
+
+#[test]
+fn provider_checkpoint_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let (bucket_id, pair) = setup_agreement_with_keypair(2, 1, 50, 500);
+
+        // Fund pool so we get a reward in the event
+        assert_ok!(StorageProvider::fund_checkpoint_pool(
+            RuntimeOrigin::signed(1),
+            bucket_id,
+            500,
+        ));
+
+        let sig = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xAA), 0, 10, 0);
+
+        assert_ok!(StorageProvider::provider_checkpoint(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0,
+            vec![sig].try_into().unwrap(),
+        ));
+
+        let expected = RuntimeEvent::StorageProvider(crate::Event::ProviderCheckpointSubmitted {
+            bucket_id,
+            mmr_root: H256::repeat_byte(0xAA),
+            window: 0,
+            leader: 2,
+            signers: vec![2],
+            reward: 10,
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn report_missed_checkpoint_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 500);
+
+        // Advance past window 0 + grace
+        run_to_block(11);
+
+        assert_ok!(StorageProvider::report_missed_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            0,
+        ));
+
+        // Penalty = CheckpointMissPenalty(50) or provider's stake if less
+        let events = frame_system::Pallet::<Test>::events();
+        let found = events.iter().any(|r| {
+            matches!(
+                &r.event,
+                RuntimeEvent::StorageProvider(crate::Event::CheckpointMissPenalized {
+                    bucket_id: bid,
+                    provider: 2,
+                    window: 0,
+                    ..
+                }) if *bid == bucket_id
+            )
+        });
+        assert!(found);
+    });
+}
+
+#[test]
+fn report_missed_checkpoint_fails_already_submitted() {
+    new_test_ext().execute_with(|| {
+        let (bucket_id, pair) = setup_agreement_with_keypair(2, 1, 50, 500);
+
+        let sig = sign_checkpoint_proposal(&pair, 2, bucket_id, H256::repeat_byte(0xAA), 0, 10, 0);
+
+        // Submit checkpoint for window 0
+        assert_ok!(StorageProvider::provider_checkpoint(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            H256::repeat_byte(0xAA),
+            0,
+            10,
+            0,
+            vec![sig].try_into().unwrap(),
+        ));
+
+        // Advance past window 0
+        run_to_block(11);
+
+        // Try to report window 0 as missed — but it was submitted
+        assert_noop!(
+            StorageProvider::report_missed_checkpoint(RuntimeOrigin::signed(3), bucket_id, 0),
+            Error::<Test>::CheckpointAlreadySubmitted
         );
     });
 }

--- a/pallet/src/tests/misc.rs
+++ b/pallet/src/tests/misc.rs
@@ -44,20 +44,15 @@ fn remove_slashed_works() {
         register_provider(2, 200);
         let bucket_id = setup_agreement(2, 1, 50, 200);
 
-        // Slash provider's stake to zero by directly manipulating storage
+        // Slash provider's entire reserved stake (mirrors production slash_provider_for_failed_challenge)
         Providers::<Test>::mutate(2, |maybe_provider| {
             if let Some(provider) = maybe_provider {
-                // Unreserve existing stake and zero it out
-                <Balances as frame_support::traits::ReservableCurrency<u64>>::unreserve(
-                    &2,
-                    provider.stake,
-                );
-                // Slash from free balance by reserving and slashing
-                let _ =
+                let stake = provider.stake;
+                let (_, remaining) =
                     <Balances as frame_support::traits::ReservableCurrency<u64>>::slash_reserved(
-                        &2,
-                        provider.stake,
+                        &2, stake,
                     );
+                assert_eq!(remaining, 0, "entire stake should have been slashed");
                 provider.stake = 0;
             }
         });
@@ -170,5 +165,161 @@ fn set_extensions_blocked_emits_event() {
         assert!(frame_system::Pallet::<Test>::events()
             .iter()
             .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn register_provider_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        register_provider(2, 200);
+
+        let expected = RuntimeEvent::StorageProvider(crate::Event::ProviderRegistered {
+            provider: 2,
+            stake: 200,
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn create_bucket_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        assert_ok!(StorageProvider::create_bucket(RuntimeOrigin::signed(1), 1));
+
+        let expected = RuntimeEvent::StorageProvider(crate::Event::BucketCreated {
+            bucket_id: 0,
+            admin: 1,
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn accept_agreement_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 100);
+
+        let expected = RuntimeEvent::StorageProvider(crate::Event::AgreementAccepted {
+            bucket_id,
+            provider: 2,
+            expires_at: 101, // block 1 + duration 100
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn challenge_checkpoint_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 200);
+
+        // Insert snapshot
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                bucket.snapshot = Some(storage_primitives::BucketSnapshot {
+                    mmr_root: sp_core::H256::repeat_byte(0xAB),
+                    start_seq: 0,
+                    leaf_count: 10,
+                    checkpoint_block: 1,
+                    primary_signers: vec![0x01],
+                });
+            }
+        });
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let expected = RuntimeEvent::StorageProvider(crate::Event::ChallengeCreated {
+            challenge_id: storage_primitives::ChallengeId {
+                deadline: 101,
+                index: 0,
+            },
+            bucket_id,
+            provider: 2,
+            challenger: 3,
+            respond_by: 101,
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn checkpoint_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        assert_ok!(StorageProvider::create_bucket(RuntimeOrigin::signed(1), 0));
+
+        assert_ok!(StorageProvider::checkpoint(
+            RuntimeOrigin::signed(1),
+            0,
+            sp_core::H256::repeat_byte(0xAA),
+            0,
+            10,
+            Default::default(),
+        ));
+
+        let expected = RuntimeEvent::StorageProvider(crate::Event::BucketCheckpointed {
+            bucket_id: 0,
+            mmr_root: sp_core::H256::repeat_byte(0xAA),
+            start_seq: 0,
+            leaf_count: 10,
+            providers: vec![],
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn end_agreement_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 100);
+
+        // Advance past agreement expiry (expires_at = 100)
+        run_to_block(101);
+
+        // End agreement after expiry (owner can end within settlement window)
+        assert_ok!(StorageProvider::end_agreement(
+            RuntimeOrigin::signed(1),
+            bucket_id,
+            2,
+            storage_primitives::EndAction::Pay,
+        ));
+
+        // Verify AgreementEnded event emitted
+        let events = frame_system::Pallet::<Test>::events();
+        let found = events.iter().any(|r| {
+            matches!(
+                &r.event,
+                RuntimeEvent::StorageProvider(crate::Event::AgreementEnded {
+                    bucket_id: bid,
+                    provider: 2,
+                    ..
+                }) if *bid == bucket_id
+            )
+        });
+        assert!(found);
     });
 }

--- a/pallet/src/tests/mod.rs
+++ b/pallet/src/tests/mod.rs
@@ -21,3 +21,4 @@ mod member_buckets;
 mod misc;
 mod provider;
 mod replica;
+mod runtime_api;

--- a/pallet/src/tests/replica.rs
+++ b/pallet/src/tests/replica.rs
@@ -228,3 +228,328 @@ fn top_up_replica_sync_balance_fails_no_agreement() {
         );
     });
 }
+
+/// Helper: set up a bucket with a primary provider (3) holding a snapshot,
+/// and a replica provider (2) with an accepted replica agreement.
+fn setup_replica_with_snapshot() -> u64 {
+    use sp_core::H256;
+    use storage_primitives::BucketSnapshot;
+
+    // Provider 3 = primary
+    register_provider(3, 200);
+    // Provider 2 = replica
+    setup_provider_with_replicas(2, 200);
+
+    // Create bucket with primary agreement on provider 3
+    let bucket_id = setup_agreement(3, 1, 50, 200);
+
+    // Insert a snapshot on the bucket (provider 3 signed)
+    Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+        if let Some(bucket) = maybe_bucket {
+            bucket.snapshot = Some(BucketSnapshot {
+                mmr_root: H256::repeat_byte(0xAB),
+                start_seq: 0,
+                leaf_count: 10,
+                checkpoint_block: 1,
+                primary_signers: vec![0x01],
+            });
+        }
+    });
+
+    // Request and accept replica agreement for provider 2
+    assert_ok!(StorageProvider::request_agreement(
+        RuntimeOrigin::signed(1),
+        bucket_id,
+        2,
+        50,
+        200,
+        10000,
+        ReplicaRequestParams {
+            sync_balance: 500,
+            min_sync_interval: 10,
+        }
+    ));
+    assert_ok!(StorageProvider::accept_agreement(
+        RuntimeOrigin::signed(2),
+        bucket_id,
+    ));
+
+    bucket_id
+}
+
+#[test]
+fn confirm_replica_sync_happy_path() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_replica_with_snapshot();
+
+        let provider_balance_before = Balances::free_balance(2);
+
+        // Sync with current snapshot root at position 0
+        let mut roots = [None; 7];
+        roots[0] = Some(sp_core::H256::repeat_byte(0xAB));
+
+        assert_ok!(StorageProvider::confirm_replica_sync(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            roots,
+            sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+        ));
+
+        // Provider should receive sync_price (10)
+        assert_eq!(Balances::free_balance(2), provider_balance_before + 10);
+
+        // Sync balance should decrease
+        let agreement = StorageAgreements::<Test>::get(bucket_id, 2).unwrap();
+        match &agreement.role {
+            storage_primitives::ProviderRole::Replica {
+                sync_balance,
+                last_sync,
+                ..
+            } => {
+                assert_eq!(*sync_balance, 490); // 500 - 10
+                assert!(last_sync.is_some());
+                let (root, block) = last_sync.unwrap();
+                assert_eq!(root, sp_core::H256::repeat_byte(0xAB));
+                assert_eq!(block, 1);
+            }
+            _ => panic!("expected replica"),
+        }
+    });
+}
+
+#[test]
+fn confirm_replica_sync_fails_sync_too_frequent() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_replica_with_snapshot();
+
+        // First sync
+        let mut roots = [None; 7];
+        roots[0] = Some(sp_core::H256::repeat_byte(0xAB));
+        assert_ok!(StorageProvider::confirm_replica_sync(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            roots,
+            sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+        ));
+
+        // Update snapshot to a new root so we don't hit InvalidSyncRoot
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                if let Some(snapshot) = &mut bucket.snapshot {
+                    snapshot.mmr_root = sp_core::H256::repeat_byte(0xCD);
+                }
+            }
+        });
+
+        // Try to sync again before min_sync_interval (10 blocks)
+        run_to_block(5); // Only 4 blocks later, need at least 10
+
+        let mut roots2 = [None; 7];
+        roots2[0] = Some(sp_core::H256::repeat_byte(0xCD));
+        assert_noop!(
+            StorageProvider::confirm_replica_sync(
+                RuntimeOrigin::signed(2),
+                bucket_id,
+                roots2,
+                sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+            ),
+            Error::<Test>::SyncTooFrequent
+        );
+    });
+}
+
+#[test]
+fn confirm_replica_sync_fails_insufficient_balance() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+
+        // Set up replica with very low sync_balance
+        register_provider(3, 200);
+        setup_provider_with_replicas(2, 200);
+        let bucket_id = setup_agreement(3, 1, 50, 200);
+
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                bucket.snapshot = Some(storage_primitives::BucketSnapshot {
+                    mmr_root: sp_core::H256::repeat_byte(0xAB),
+                    start_seq: 0,
+                    leaf_count: 10,
+                    checkpoint_block: 1,
+                    primary_signers: vec![0x01],
+                });
+            }
+        });
+
+        // Request replica with sync_balance < sync_price
+        assert_ok!(StorageProvider::request_agreement(
+            RuntimeOrigin::signed(1),
+            bucket_id,
+            2,
+            50,
+            200,
+            10000,
+            ReplicaRequestParams {
+                sync_balance: 5, // Less than sync_price (10)
+                min_sync_interval: 10,
+            }
+        ));
+        assert_ok!(StorageProvider::accept_agreement(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+        ));
+
+        let mut roots = [None; 7];
+        roots[0] = Some(sp_core::H256::repeat_byte(0xAB));
+
+        assert_noop!(
+            StorageProvider::confirm_replica_sync(
+                RuntimeOrigin::signed(2),
+                bucket_id,
+                roots,
+                sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+            ),
+            Error::<Test>::InsufficientSyncBalance
+        );
+    });
+}
+
+#[test]
+fn confirm_replica_sync_fails_invalid_root() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_replica_with_snapshot();
+
+        // Provide a root that doesn't match snapshot or historical roots
+        let mut roots = [None; 7];
+        roots[0] = Some(sp_core::H256::repeat_byte(0xFF)); // Wrong root
+
+        assert_noop!(
+            StorageProvider::confirm_replica_sync(
+                RuntimeOrigin::signed(2),
+                bucket_id,
+                roots,
+                sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+            ),
+            Error::<Test>::InvalidSyncRoot
+        );
+    });
+}
+
+#[test]
+fn confirm_replica_sync_fails_same_root() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_replica_with_snapshot();
+
+        // First sync succeeds
+        let mut roots = [None; 7];
+        roots[0] = Some(sp_core::H256::repeat_byte(0xAB));
+        assert_ok!(StorageProvider::confirm_replica_sync(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            roots,
+            sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+        ));
+
+        // Advance past min_sync_interval
+        run_to_block(12);
+
+        // Try to sync with same root — should fail
+        assert_noop!(
+            StorageProvider::confirm_replica_sync(
+                RuntimeOrigin::signed(2),
+                bucket_id,
+                roots,
+                sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+            ),
+            Error::<Test>::InvalidSyncRoot
+        );
+    });
+}
+
+#[test]
+fn confirm_replica_sync_emits_event() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_replica_with_snapshot();
+
+        let mut roots = [None; 7];
+        roots[0] = Some(sp_core::H256::repeat_byte(0xAB));
+
+        assert_ok!(StorageProvider::confirm_replica_sync(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            roots,
+            sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+        ));
+
+        let expected = RuntimeEvent::StorageProvider(crate::Event::ReplicaSynced {
+            bucket_id,
+            provider: 2,
+            mmr_root: sp_core::H256::repeat_byte(0xAB),
+            position_matched: 0,
+            sync_payment: 10,
+        });
+        assert!(frame_system::Pallet::<Test>::events()
+            .iter()
+            .any(|r| r.event == expected));
+    });
+}
+
+#[test]
+fn confirm_replica_sync_after_interval_with_new_root() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_replica_with_snapshot();
+
+        // First sync
+        let mut roots = [None; 7];
+        roots[0] = Some(sp_core::H256::repeat_byte(0xAB));
+        assert_ok!(StorageProvider::confirm_replica_sync(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            roots,
+            sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+        ));
+
+        // Update snapshot root
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                if let Some(snapshot) = &mut bucket.snapshot {
+                    snapshot.mmr_root = sp_core::H256::repeat_byte(0xCD);
+                }
+            }
+        });
+
+        // Advance past min_sync_interval (10)
+        run_to_block(12);
+
+        // Second sync with new root should succeed
+        let mut roots2 = [None; 7];
+        roots2[0] = Some(sp_core::H256::repeat_byte(0xCD));
+        assert_ok!(StorageProvider::confirm_replica_sync(
+            RuntimeOrigin::signed(2),
+            bucket_id,
+            roots2,
+            sp_runtime::MultiSignature::Sr25519([0u8; 64].into()),
+        ));
+
+        // Verify last_sync updated
+        let agreement = StorageAgreements::<Test>::get(bucket_id, 2).unwrap();
+        match &agreement.role {
+            storage_primitives::ProviderRole::Replica {
+                sync_balance,
+                last_sync,
+                ..
+            } => {
+                assert_eq!(*sync_balance, 480); // 500 - 10 - 10
+                let (root, block) = last_sync.unwrap();
+                assert_eq!(root, sp_core::H256::repeat_byte(0xCD));
+                assert_eq!(block, 12);
+            }
+            _ => panic!("expected replica"),
+        }
+    });
+}

--- a/pallet/src/tests/runtime_api.rs
+++ b/pallet/src/tests/runtime_api.rs
@@ -1,0 +1,282 @@
+use super::*;
+use codec::Encode;
+use sp_core::H256;
+use storage_primitives::BucketSnapshot;
+
+#[test]
+fn query_provider_info_returns_data() {
+    new_test_ext().execute_with(|| {
+        register_provider(2, 200);
+
+        let info = StorageProvider::query_provider_info(&2);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.stake, 200);
+        assert_eq!(info.committed_bytes, 0);
+        assert!(info.accepting_primary);
+    });
+}
+
+#[test]
+fn query_provider_info_none_for_unknown() {
+    new_test_ext().execute_with(|| {
+        let info = StorageProvider::query_provider_info(&99);
+        assert!(info.is_none());
+    });
+}
+
+#[test]
+fn query_bucket_info_returns_data() {
+    new_test_ext().execute_with(|| {
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 200);
+
+        // Insert snapshot
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                bucket.snapshot = Some(BucketSnapshot {
+                    mmr_root: H256::repeat_byte(0xAB),
+                    start_seq: 0,
+                    leaf_count: 10,
+                    checkpoint_block: 1,
+                    primary_signers: vec![0x01],
+                });
+            }
+        });
+
+        let response = StorageProvider::query_bucket_info(bucket_id);
+        assert!(response.is_some());
+        let response = response.unwrap();
+        assert_eq!(response.bucket_id, bucket_id);
+        assert_eq!(response.min_providers, 1);
+        assert!(!response.members.is_empty());
+        assert!(response.snapshot.is_some());
+        let snapshot = response.snapshot.unwrap();
+        assert_eq!(snapshot.mmr_root, H256::repeat_byte(0xAB));
+        assert_eq!(snapshot.leaf_count, 10);
+
+        // Primary providers should include provider 2
+        assert!(!response.primary_providers.is_empty());
+        assert!(response.primary_providers.contains(&2u64.encode()));
+    });
+}
+
+#[test]
+fn query_bucket_info_none_for_unknown() {
+    new_test_ext().execute_with(|| {
+        let response = StorageProvider::query_bucket_info(999);
+        assert!(response.is_none());
+    });
+}
+
+#[test]
+fn query_agreement_info_returns_data() {
+    new_test_ext().execute_with(|| {
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 200);
+
+        let response = StorageProvider::query_agreement_info(bucket_id, &2);
+        assert!(response.is_some());
+        let response = response.unwrap();
+        assert_eq!(response.max_bytes, 50);
+        assert_eq!(response.owner, 1u64.encode());
+        assert_eq!(response.provider, 2u64.encode());
+        assert!(!response.extensions_blocked);
+        assert!(matches!(
+            response.role,
+            storage_primitives::ProviderRole::Primary
+        ));
+    });
+}
+
+#[test]
+fn query_agreement_info_none_for_unknown() {
+    new_test_ext().execute_with(|| {
+        let response = StorageProvider::query_agreement_info(999, &2);
+        assert!(response.is_none());
+    });
+}
+
+#[test]
+fn can_accept_bytes_checks_capacity() {
+    new_test_ext().execute_with(|| {
+        // Provider with max_capacity set
+        register_provider_with_settings(
+            2,
+            200,
+            ProviderSettings {
+                accepting_primary: true,
+                max_capacity: 100,
+                ..Default::default()
+            },
+        );
+
+        // Can accept 50 bytes (well within capacity and stake covers it)
+        assert!(StorageProvider::query_can_accept_bytes(&2, 50));
+
+        // Can accept 100 bytes (at capacity limit)
+        assert!(StorageProvider::query_can_accept_bytes(&2, 100));
+
+        // Cannot accept 101 bytes (exceeds capacity)
+        assert!(!StorageProvider::query_can_accept_bytes(&2, 101));
+
+        // Non-existent provider
+        assert!(!StorageProvider::query_can_accept_bytes(&99, 10));
+    });
+}
+
+#[test]
+fn can_accept_bytes_unlimited_capacity() {
+    new_test_ext().execute_with(|| {
+        // Provider with max_capacity = 0 (unlimited)
+        register_provider(2, 200);
+
+        // Unlimited capacity — only stake constraint matters
+        // stake = 200, MinStakePerByte = 1, so can accept up to 200 bytes
+        assert!(StorageProvider::query_can_accept_bytes(&2, 100));
+        assert!(StorageProvider::query_can_accept_bytes(&2, 200));
+        assert!(!StorageProvider::query_can_accept_bytes(&2, 201));
+    });
+}
+
+#[test]
+fn find_matching_providers_scores() {
+    new_test_ext().execute_with(|| {
+        // Register a provider that matches requirements
+        // stake >= max_capacity * MinStakePerByte(1) → need stake >= 1000
+        register_provider_with_settings(
+            2,
+            1000,
+            ProviderSettings {
+                accepting_primary: true,
+                max_capacity: 1000,
+                price_per_byte: 5,
+                min_duration: 10,
+                max_duration: 500,
+                ..Default::default()
+            },
+        );
+
+        let requirements = crate::runtime_api::StorageRequirements {
+            bytes_needed: 100,
+            min_duration: 50,
+            max_price_per_byte: 10,
+            primary_only: true,
+        };
+
+        let results = StorageProvider::query_find_matching_providers(requirements, 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_score, 100); // Perfect match
+        assert!(results[0].partial_reason.is_none());
+    });
+}
+
+#[test]
+fn find_matching_providers_partial_score() {
+    new_test_ext().execute_with(|| {
+        // Register a provider with price too high
+        // stake >= max_capacity * MinStakePerByte(1) → need stake >= 1000
+        register_provider_with_settings(
+            2,
+            1000,
+            ProviderSettings {
+                accepting_primary: true,
+                max_capacity: 1000,
+                price_per_byte: 20,
+                min_duration: 10,
+                max_duration: 500,
+                ..Default::default()
+            },
+        );
+
+        let requirements = crate::runtime_api::StorageRequirements {
+            bytes_needed: 100,
+            min_duration: 50,
+            max_price_per_byte: 10, // Provider price is 20, exceeds this
+            primary_only: true,
+        };
+
+        let results = StorageProvider::query_find_matching_providers(requirements, 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_score, 70); // 100 - 30 for price
+        assert_eq!(
+            results[0].partial_reason,
+            Some(crate::runtime_api::PartialMatchReason::PriceTooHigh)
+        );
+    });
+}
+
+#[test]
+fn find_matching_providers_not_accepting() {
+    new_test_ext().execute_with(|| {
+        // Register a provider that is NOT accepting primary
+        register_provider_with_settings(
+            2,
+            200,
+            ProviderSettings {
+                accepting_primary: false,
+                ..Default::default()
+            },
+        );
+
+        let requirements = crate::runtime_api::StorageRequirements {
+            bytes_needed: 10,
+            min_duration: 10,
+            max_price_per_byte: 100,
+            primary_only: true,
+        };
+
+        let results = StorageProvider::query_find_matching_providers(requirements, 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_score, 0); // Not accepting = score 0
+    });
+}
+
+#[test]
+fn query_bucket_providers_returns_list() {
+    new_test_ext().execute_with(|| {
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 200);
+
+        let providers = StorageProvider::query_bucket_providers(bucket_id);
+        assert_eq!(providers, vec![2]);
+    });
+}
+
+#[test]
+fn query_challenges_at_returns_data() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        register_provider(2, 200);
+        let bucket_id = setup_agreement(2, 1, 50, 200);
+
+        // Insert snapshot
+        Buckets::<Test>::mutate(bucket_id, |maybe_bucket| {
+            if let Some(bucket) = maybe_bucket {
+                bucket.snapshot = Some(BucketSnapshot {
+                    mmr_root: H256::repeat_byte(0xAB),
+                    start_seq: 0,
+                    leaf_count: 10,
+                    checkpoint_block: 1,
+                    primary_signers: vec![0x01],
+                });
+            }
+        });
+
+        assert_ok!(StorageProvider::challenge_checkpoint(
+            RuntimeOrigin::signed(3),
+            bucket_id,
+            2,
+            0,
+            0,
+        ));
+
+        let challenges = StorageProvider::query_challenges_at(101);
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].bucket_id, bucket_id);
+        assert_eq!(challenges[0].provider, 2u64.encode());
+        assert_eq!(challenges[0].challenger, 3u64.encode());
+        assert_eq!(challenges[0].deadline, 101);
+        assert_eq!(challenges[0].deposit, 100);
+    });
+}


### PR DESCRIPTION
## Summary

#144 

Split from #139 (PR 2 of 4). Independent of the other PRs — pallet-only changes.

Add comprehensive test coverage for the storage-provider pallet:

- **Challenge tests**: cost-split boundary conditions, offchain challenge flows
- **Checkpoint tests**: scheduling, fallback, leader election, missed checkpoint handling
- **Misc tests**: event emission, `remove_slashed`, multiaddr validation
- **Replica tests**: full replica sync lifecycle
- **Runtime API tests**: provider/bucket/agreement query coverage

## PR stack

| # | PR | Base | Description |
|---|---|---|---|
| 1 | #145 | `dev` | Refactor + CI |
| **2** | **This PR** | `dev` | **Pallet tests (independent)** |
| 3 | test/provider-node-http-tests | #145 | HTTP integration tests |
| 4 | test/coordinator-and-fs-pallet-tests | PR 3 | Coordinator + FS tests |

## Test plan

- [ ] `cargo test -p pallet-storage-provider` passes
- [ ] No runtime or production code changes — pure test additions