### PR TITLE
fix(ci): retry on stale nonce in SC integration tests

### DIFF
--- a/examples/papi/common.js
+++ b/examples/papi/common.js
@@ -355,14 +355,33 @@ export async function waitForTransaction(
  *
  * Best blocks can be reorged, so for a tx whose effect a LATER tx references by
  * id (e.g. create a challenge, then respond to it) use `submitTxFinalized`.
+ *
+ * Retries up to `STALE_RETRIES` times on `Invalid::Stale` (nonce too low).
+ * This happens when back-to-back CI tests reuse the same signing account and
+ * the PAPI client's nonce view lags behind the chain's best block.
  */
+const STALE_RETRIES = 3;
+const STALE_RETRY_DELAY_MS = 6_500; // ~1 block time
+
 export async function submitTx(
   tx,
   signer,
   label,
   timeoutMs = DEFAULT_TX_TIMEOUT_MS
 ) {
-  return waitForTransaction(tx, signer, label, TX_MODE_IN_BLOCK, timeoutMs);
+  for (let attempt = 1; attempt <= STALE_RETRIES; attempt++) {
+    try {
+      return await waitForTransaction(tx, signer, label, TX_MODE_IN_BLOCK, timeoutMs);
+    } catch (err) {
+      const isStale = /Invalid.*Stale|Stale.*nonce/i.test(err.message);
+      if (!isStale || attempt === STALE_RETRIES) throw err;
+      console.warn(
+        `  ⚠ ${label}: stale nonce (attempt ${attempt}/${STALE_RETRIES}), ` +
+        `waiting ${STALE_RETRY_DELAY_MS}ms for next block…`
+      );
+      await new Promise((r) => setTimeout(r, STALE_RETRY_DELAY_MS));
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the flaky `sc-token-gated` CI failure (`Invalid::Stale` during `Revive.instantiate_with_code`).

**Root cause**: When back-to-back SC integration tests (`sc-flow` → `sc-coverage` → `sc-team-drive` → `sc-token-gated`) reuse the same `//Bob` account, PAPI's internal nonce view can lag behind the chain's best block. The `drain-pool` recipe waits for the tx pool to empty, but the PAPI client created by the next test may still read a stale nonce at sign time, causing the node to reject the tx as `Invalid::Stale`.

**Fix**: Add retry logic in `submitTx()` — on `Invalid::Stale` errors, wait ~1 block time (6.5s) and retry, up to 3 attempts. Non-stale errors propagate immediately.

This failure reproduces on `dev` itself (not just PRs): [run 26984399618](https://github.com/paritytech/web3-storage/actions/runs/26984399618) from June 4.

## Test plan

- [x] SC Integration Tests pass (both runtimes)
- [x] Existing integration tests unaffected (retry only triggers on `Stale`)