### PR TITLE
fix(ci): pass explicit best-block nonce for SC contract txs

### DIFF
--- a/examples/papi/common.js
+++ b/examples/papi/common.js
@@ -346,6 +346,41 @@ export async function waitForTransaction(
   });
 }
 
+// Retry budget for `Invalid::Stale` (nonce too low). Stale happens two ways on
+// these dev chains: a fresh PAPI client whose nonce view trails the chain, and
+// the provider account racing the provider node's coordinators, which sign from
+// the same key. Contract calls pass an explicit best-block nonce to avoid the
+// first case deterministically; this retry is the backstop for the race, which
+// no pre-read can fully prevent. On retry we drop any explicit nonce so PAPI
+// re-reads a fresh one; re-submitting the same stale nonce would just fail.
+const STALE_RETRIES = 3;
+const STALE_RETRY_DELAY_MS = 6_500; // ~3 blocks at 2s
+
+async function submitWithStaleRetry(txMode, tx, signer, label, timeoutMs, txOpts) {
+  for (let attempt = 1; attempt <= STALE_RETRIES; attempt++) {
+    const opts = attempt === 1 ? txOpts : { ...txOpts, nonce: undefined };
+    try {
+      return await waitForTransaction(
+        tx,
+        signer,
+        label,
+        txMode,
+        timeoutMs,
+        null,
+        opts
+      );
+    } catch (err) {
+      const isStale = /\bStale\b/i.test(String(err?.message ?? err));
+      if (!isStale || attempt === STALE_RETRIES) throw err;
+      console.warn(
+        `  ⚠ ${label}: stale nonce (attempt ${attempt}/${STALE_RETRIES}), ` +
+          `retrying in ${STALE_RETRY_DELAY_MS}ms with a fresh nonce…`
+      );
+      await new Promise((r) => setTimeout(r, STALE_RETRY_DELAY_MS));
+    }
+  }
+}
+
 /**
  * Sign + submit a tx, assert it dispatched OK, return the in-block event
  * (`{ ok, events, ... }`). Resolves at inclusion, not finalization — ~6x faster
@@ -363,13 +398,12 @@ export async function submitTx(
   timeoutMs = DEFAULT_TX_TIMEOUT_MS,
   txOpts = {}
 ) {
-  return waitForTransaction(
+  return submitWithStaleRetry(
+    TX_MODE_IN_BLOCK,
     tx,
     signer,
     label,
-    TX_MODE_IN_BLOCK,
     timeoutMs,
-    null,
     txOpts
   );
 }
@@ -387,13 +421,12 @@ export async function submitTxFinalized(
   timeoutMs = DEFAULT_TX_TIMEOUT_MS,
   txOpts = {}
 ) {
-  return waitForTransaction(
+  return submitWithStaleRetry(
+    TX_MODE_FINALIZED_BLOCK,
     tx,
     signer,
     label,
-    TX_MODE_FINALIZED_BLOCK,
     timeoutMs,
-    null,
     txOpts
   );
 }

--- a/examples/papi/common.js
+++ b/examples/papi/common.js
@@ -360,9 +360,18 @@ export async function submitTx(
   tx,
   signer,
   label,
-  timeoutMs = DEFAULT_TX_TIMEOUT_MS
+  timeoutMs = DEFAULT_TX_TIMEOUT_MS,
+  txOpts = {}
 ) {
-  return waitForTransaction(tx, signer, label, TX_MODE_IN_BLOCK, timeoutMs);
+  return waitForTransaction(
+    tx,
+    signer,
+    label,
+    TX_MODE_IN_BLOCK,
+    timeoutMs,
+    null,
+    txOpts
+  );
 }
 
 /**
@@ -375,14 +384,17 @@ export async function submitTxFinalized(
   tx,
   signer,
   label,
-  timeoutMs = DEFAULT_TX_TIMEOUT_MS
+  timeoutMs = DEFAULT_TX_TIMEOUT_MS,
+  txOpts = {}
 ) {
   return waitForTransaction(
     tx,
     signer,
     label,
     TX_MODE_FINALIZED_BLOCK,
-    timeoutMs
+    timeoutMs,
+    null,
+    txOpts
   );
 }
 

--- a/examples/papi/common.js
+++ b/examples/papi/common.js
@@ -349,10 +349,9 @@ export async function waitForTransaction(
 // Retry budget for `Invalid::Stale` (nonce too low). Stale happens two ways on
 // these dev chains: a fresh PAPI client whose nonce view trails the chain, and
 // the provider account racing the provider node's coordinators, which sign from
-// the same key. Contract calls pass an explicit best-block nonce to avoid the
-// first case deterministically; this retry is the backstop for the race, which
-// no pre-read can fully prevent. On retry we drop any explicit nonce so PAPI
-// re-reads a fresh one; re-submitting the same stale nonce would just fail.
+// the same key. On retry we wait ~a block for the chain to advance and drop any
+// explicit nonce so PAPI re-reads a fresh one; re-submitting the same stale
+// nonce would just fail again.
 const STALE_RETRIES = 3;
 const STALE_RETRY_DELAY_MS = 6_500; // ~3 blocks at 2s
 

--- a/examples/papi/sc-api.js
+++ b/examples/papi/sc-api.js
@@ -15,30 +15,11 @@ import { decodeEventLog, encodeFunctionData, keccak256 } from "viem";
 
 import {
   hexToBytes,
-  READ_OPTS,
   requireOneEvent,
   submitTx,
   submitTxFinalized,
   toHex,
 } from "./common.js";
-
-/**
- * Read `signer`'s nonce from the BEST block and return it as PAPI `txOpts`.
- *
- * A fresh PAPI client's internal nonce view can trail the chain when
- * back-to-back CI tests reuse the same signing account, so its first submit is
- * rejected as `Invalid::Stale` (nonce too low). Reading the nonce ourselves
- * from the best block (a finalized read lags ~6 blocks and is itself stale)
- * and passing it explicitly sidesteps that cache. Contract calls await
- * in-block before returning, so the next read already sees the bump.
- */
-async function bestBlockNonceOpts(api, signer) {
-  const account = await api.query.System.Account.getValue(
-    signer.address,
-    READ_OPTS
-  );
-  return { nonce: account.nonce };
-}
 
 /**
  * Compute the EVM-side H160 of a substrate account via `AccountId32Mapper`'s
@@ -79,9 +60,7 @@ export async function ensureAccountMapped(api, signer) {
     await submitTx(
       api.tx.Revive.map_account(),
       signer.signer,
-      `Revive.map_account(${signer.seed})`,
-      undefined,
-      await bestBlockNonceOpts(api, signer)
+      `Revive.map_account(${signer.seed})`
     );
   } catch (e) {
     const msg = String(e?.message ?? e);
@@ -116,13 +95,7 @@ export async function deployContract(
     salt: salt ? Binary.fromBytes(salt) : undefined,
   });
 
-  const result = await submitTx(
-    tx,
-    deployer.signer,
-    "Revive.instantiate_with_code",
-    undefined,
-    await bestBlockNonceOpts(api, deployer)
-  );
+  const result = await submitTx(tx, deployer.signer, "Revive.instantiate_with_code");
   const instantiated = requireOneEvent(
     result.events,
     api.event.Revive.Instantiated,
@@ -163,13 +136,7 @@ export async function callContract(
     data: Binary.fromBytes(data),
   });
   const submit = finalized ? submitTxFinalized : submitTx;
-  return submit(
-    tx,
-    signer.signer,
-    "Revive.call",
-    undefined,
-    await bestBlockNonceOpts(api, signer)
-  );
+  return submit(tx, signer.signer, "Revive.call");
 }
 
 /**

--- a/examples/papi/sc-api.js
+++ b/examples/papi/sc-api.js
@@ -15,11 +15,30 @@ import { decodeEventLog, encodeFunctionData, keccak256 } from "viem";
 
 import {
   hexToBytes,
+  READ_OPTS,
   requireOneEvent,
   submitTx,
   submitTxFinalized,
   toHex,
 } from "./common.js";
+
+/**
+ * Read `signer`'s nonce from the BEST block and return it as PAPI `txOpts`.
+ *
+ * A fresh PAPI client's internal nonce view can trail the chain when
+ * back-to-back CI tests reuse the same signing account, so its first submit is
+ * rejected as `Invalid::Stale` (nonce too low). Reading the nonce ourselves
+ * from the best block (a finalized read lags ~6 blocks and is itself stale)
+ * and passing it explicitly sidesteps that cache. Contract calls await
+ * in-block before returning, so the next read already sees the bump.
+ */
+async function bestBlockNonceOpts(api, signer) {
+  const account = await api.query.System.Account.getValue(
+    signer.address,
+    READ_OPTS
+  );
+  return { nonce: account.nonce };
+}
 
 /**
  * Compute the EVM-side H160 of a substrate account via `AccountId32Mapper`'s
@@ -60,7 +79,9 @@ export async function ensureAccountMapped(api, signer) {
     await submitTx(
       api.tx.Revive.map_account(),
       signer.signer,
-      `Revive.map_account(${signer.seed})`
+      `Revive.map_account(${signer.seed})`,
+      undefined,
+      await bestBlockNonceOpts(api, signer)
     );
   } catch (e) {
     const msg = String(e?.message ?? e);
@@ -95,7 +116,13 @@ export async function deployContract(
     salt: salt ? Binary.fromBytes(salt) : undefined,
   });
 
-  const result = await submitTx(tx, deployer.signer, "Revive.instantiate_with_code");
+  const result = await submitTx(
+    tx,
+    deployer.signer,
+    "Revive.instantiate_with_code",
+    undefined,
+    await bestBlockNonceOpts(api, deployer)
+  );
   const instantiated = requireOneEvent(
     result.events,
     api.event.Revive.Instantiated,
@@ -136,7 +163,13 @@ export async function callContract(
     data: Binary.fromBytes(data),
   });
   const submit = finalized ? submitTxFinalized : submitTx;
-  return submit(tx, signer.signer, "Revive.call");
+  return submit(
+    tx,
+    signer.signer,
+    "Revive.call",
+    undefined,
+    await bestBlockNonceOpts(api, signer)
+  );
 }
 
 /**


### PR DESCRIPTION
Builds on #150. The stale-nonce race surfaces on more than the contract path: CI hit it on the provider account (`//Alice`) during setup, which the provider node's coordinators sign with too. Two refinements to the retry:

- Apply it to `submitTxFinalized` as well as `submitTx` (the challenge paths use finalized submits and can stale the same way).
- On retry, drop any explicit nonce so PAPI re-reads a fresh one, and match `Stale` directly rather than via a message-format-specific regex.

I first tried passing an explicit best-block nonce on the contract calls, but that could read a nonce already ahead of the validating context, leaving the tx in Future and timing out after 180s (a `Revive.call` timeout on web3-storage-paseo) — and the Stale retry can't recover from that. Reverted; the retry alone covers the race.

Verified locally (omni-node dev chain + inmemory provider, web3-storage-paseo runtime): the full CI sequence `sc-flow` → `sc-coverage` → `sc-team-drive` → `sc-token-gated` with drain between, 3 iterations, 12/12 pass. Also forced a real "nonce too low" stale and confirmed `submitTx` retried with a fresh nonce and the tx landed.