### PR TITLE
Harden GitHub Actions with zizmor

### DIFF
--- a/.github/actions/start-e2e-chain/action.yml
+++ b/.github/actions/start-e2e-chain/action.yml
@@ -24,27 +24,32 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        CHAIN_SPEC_SCRIPT: ${{ inputs.chain-spec-script }}
+        BLOCK_TIME: ${{ inputs.block-time }}
+        RPC_PORT: ${{ inputs.rpc-port }}
+        LOG_FILE: ${{ inputs.log-file }}
       run: |
         SPEC_FILE="/tmp/e2e-chain-spec.json"
-        echo "Generating chain spec from ${{ inputs.chain-spec-script }}..."
-        ${{ inputs.chain-spec-script }} > "$SPEC_FILE"
+        echo "Generating chain spec from ${CHAIN_SPEC_SCRIPT}..."
+        $CHAIN_SPEC_SCRIPT > "$SPEC_FILE"
 
-        echo "Starting polkadot-omni-node with ${{ inputs.block-time }}ms blocks..."
+        echo "Starting polkadot-omni-node with ${BLOCK_TIME}ms blocks..."
         nohup .bin/polkadot-omni-node \
           --chain "$SPEC_FILE" \
           --alice --tmp \
           --unsafe-force-node-key-generation \
-          --dev-block-time ${{ inputs.block-time }} \
-          --rpc-port ${{ inputs.rpc-port }} \
+          --dev-block-time "$BLOCK_TIME" \
+          --rpc-port "$RPC_PORT" \
           --rpc-cors all \
           -lruntime=info \
-          > ${{ inputs.log-file }} 2>&1 &
+          > "$LOG_FILE" 2>&1 &
 
         NODE_PID=$!
         sleep 10
         if ! kill -0 $NODE_PID 2>/dev/null; then
           echo "ERROR: polkadot-omni-node exited early"
-          cat "${{ inputs.log-file }}" || true
+          cat "$LOG_FILE" || true
           exit 1
         fi
-        echo "polkadot-omni-node running with ${{ inputs.block-time }}ms blocks (PID $NODE_PID)"
+        echo "polkadot-omni-node running with ${BLOCK_TIME}ms blocks (PID $NODE_PID)"

--- a/.github/actions/start-zombienet/action.yml
+++ b/.github/actions/start-zombienet/action.yml
@@ -21,15 +21,19 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        CONFIG: ${{ inputs.config }}
+        LOG_FILE: ${{ inputs.log-file }}
+        STARTUP_DELAY: ${{ inputs.startup-delay }}
       run: |
-        nohup env PROJECT_ROOT=$(pwd) .bin/zombienet spawn -p native ${{ inputs.config }} \
-          > ${{ inputs.log-file }} 2>&1 &
+        nohup env PROJECT_ROOT=$(pwd) .bin/zombienet spawn -p native "$CONFIG" \
+          > "$LOG_FILE" 2>&1 &
         ZOMBIE_PID=$!
-        echo "Waiting ${{ inputs.startup-delay }}s for zombienet to set up nodes..."
-        sleep ${{ inputs.startup-delay }}
+        echo "Waiting ${STARTUP_DELAY}s for zombienet to set up nodes..."
+        sleep "$STARTUP_DELAY"
         if ! kill -0 $ZOMBIE_PID 2>/dev/null; then
           echo "ERROR: zombienet exited early"
-          cat "${{ inputs.log-file }}" || true
+          cat "$LOG_FILE" || true
           exit 1
         fi
         echo "Zombienet is running (PID $ZOMBIE_PID)"

--- a/.github/actions/wait-for-parachain/action.yml
+++ b/.github/actions/wait-for-parachain/action.yml
@@ -30,23 +30,28 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        MIN_BLOCK: ${{ inputs.min-block }}
+        ATTEMPTS: ${{ inputs.attempts }}
+        RPC_URL: ${{ inputs.rpc-url }}
+        LOG_FILE: ${{ inputs.log-file }}
       run: |
-        echo "Waiting for parachain to produce blocks (min #${{ inputs.min-block }})..."
-        for i in $(seq 1 ${{ inputs.attempts }}); do
+        echo "Waiting for parachain to produce blocks (min #${MIN_BLOCK})..."
+        for i in $(seq 1 "$ATTEMPTS"); do
           HEADER=$(curl -s -H "Content-Type: application/json" \
             -d '{"id":1,"jsonrpc":"2.0","method":"chain_getHeader","params":[]}' \
-            "${{ inputs.rpc-url }}" 2>/dev/null) || true
+            "$RPC_URL" 2>/dev/null) || true
           BLOCK_HEX=$(echo "$HEADER" | jq -r '.result.number // empty' 2>/dev/null)
           if [ -n "$BLOCK_HEX" ]; then
             BLOCK_NUM=$((BLOCK_HEX))
-            if [ "$BLOCK_NUM" -ge ${{ inputs.min-block }} ]; then
+            if [ "$BLOCK_NUM" -ge "$MIN_BLOCK" ]; then
               echo "Parachain best block: #$BLOCK_NUM (attempt $i)"
               break
             fi
           fi
-          if [ "$i" -eq ${{ inputs.attempts }} ]; then
-            echo "TIMEOUT: parachain did not produce block #${{ inputs.min-block }}"
-            cat "${{ inputs.log-file }}" 2>/dev/null || true
+          if [ "$i" -eq "$ATTEMPTS" ]; then
+            echo "TIMEOUT: parachain did not produce block #${MIN_BLOCK}"
+            cat "$LOG_FILE" 2>/dev/null || true
             exit 1
           fi
           sleep 5

--- a/.github/actions/wait-for-provider-health/action.yml
+++ b/.github/actions/wait-for-provider-health/action.yml
@@ -25,16 +25,21 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        URL: ${{ inputs.url }}
+        ATTEMPTS: ${{ inputs.attempts }}
+        LABEL: ${{ inputs.label }}
+        LOG_FILE: ${{ inputs.log-file }}
       run: |
-        echo "Waiting for ${{ inputs.label }} provider (${{ inputs.url }})..."
-        for i in $(seq 1 ${{ inputs.attempts }}); do
-          if curl -s "${{ inputs.url }}/health" | jq -e '.status' > /dev/null 2>&1; then
-            echo "${{ inputs.label }} provider is healthy (attempt $i)"
+        echo "Waiting for ${LABEL} provider (${URL})..."
+        for i in $(seq 1 "$ATTEMPTS"); do
+          if curl -s "${URL}/health" | jq -e '.status' > /dev/null 2>&1; then
+            echo "${LABEL} provider is healthy (attempt $i)"
             break
           fi
-          if [ "$i" -eq ${{ inputs.attempts }} ]; then
-            echo "Timeout: ${{ inputs.label }} provider did not become healthy"
-            cat "${{ inputs.log-file }}" 2>/dev/null || true
+          if [ "$i" -eq "$ATTEMPTS" ]; then
+            echo "Timeout: ${LABEL} provider did not become healthy"
+            cat "$LOG_FILE" 2>/dev/null || true
             exit 1
           fi
           sleep 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   set-image:
     uses: ./.github/workflows/set-image.yml
@@ -23,6 +26,8 @@ jobs:
       image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Cargo fmt
         run: |
@@ -51,6 +56,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -76,6 +83,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -100,6 +109,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -123,6 +134,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -158,6 +171,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -207,11 +221,13 @@ jobs:
           echo "PR provider coverage: ${PROVIDER_COV}%"
 
       - name: Measure base branch coverage
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           # Container user differs from repo owner; allow git operations
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git stash --include-untracked 2>/dev/null || true
-          git checkout ${{ github.event.pull_request.base.sha }}
+          git checkout "$BASE_SHA"
 
           cargo llvm-cov clean --workspace 2>/dev/null || true
 

--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -21,9 +21,6 @@ on:
       is_org_member:
         description: "Is the user an org member"
         required: true
-      is_pr_author:
-        description: "Is the user the PR author"
-        required: true
       repo:
         description: "Repository to use"
         required: true
@@ -35,16 +32,15 @@ on:
         required: false
         default: "false"
 
-permissions:
-  # allow the action to comment on the PR
-  contents: read
-  issues: write
-  pull-requests: write
-  actions: read
+# Least-privilege by default — each job grants only the scopes it needs.
+permissions: {}
 
 jobs:
   before-cmd:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read # read this run's jobs via the REST API
+      issues: write # comment on the PR
     env:
       JOB_NAME: "cmd"
       CMD: ${{ github.event.inputs.cmd }}
@@ -62,12 +58,12 @@ jobs:
           jobLink=$(curl -s \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[] | select(.name | contains("${{ env.JOB_NAME }}")) | .html_url')
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq -r '.jobs[] | select(.name | contains("${{ env.JOB_NAME }}")) | .html_url')
 
           runLink=$(curl -s \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq '.html_url')
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r '.html_url')
 
           echo "job_url=${jobLink}"
           echo "run_url=${runLink}"
@@ -79,13 +75,15 @@ jobs:
         if: ${{ github.event.inputs.is_quiet == 'false' &&
           !startsWith(github.event.inputs.cmd, 'fmt') }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          JOB_URL: ${{ steps.build-link.outputs.job_url }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            let job_url = ${{ steps.build-link.outputs.job_url }}
+            let job_url = process.env.JOB_URL || '';
             let cmd = process.env.CMD;
             github.rest.issues.createComment({
-              issue_number: ${{ env.PR_NUM }},
+              issue_number: Number(process.env.PR_NUM),
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Command "${cmd}" has started 🚀 [See logs here](${job_url})`
@@ -139,6 +137,7 @@ jobs:
         with:
           repository: ${{ env.REPO }}
           ref: ${{ env.PR_BRANCH }}
+          persist-credentials: false
 
       - name: Load .github/env
         if: startsWith(github.event.inputs.cmd, 'bench')
@@ -159,7 +158,7 @@ jobs:
       - name: Download frame-omni-bencher
         if: startsWith(github.event.inputs.cmd, 'bench') &&
           steps.bencher-cache.outputs.cache-hit != 'true'
-        run: just polkadot_version=${{ env.POLKADOT_SDK_VERSION }}
+        run: just polkadot_version="$POLKADOT_SDK_VERSION"
           download-frame-omni-bencher
 
       - name: Add .bin to PATH
@@ -170,7 +169,6 @@ jobs:
         id: cmd
         env:
           IS_ORG_MEMBER: ${{ github.event.inputs.is_org_member }}
-          IS_PR_AUTHOR: ${{ github.event.inputs.is_pr_author }}
           RUNNER: ${{ github.event.inputs.runner }}
           IMAGE: ${{ github.event.inputs.image }}
         run: |
@@ -293,6 +291,9 @@ jobs:
       PR_NUM: ${{ github.event.inputs.pr_num }}
       REPO: ${{ github.event.inputs.repo }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout via GITHUB_TOKEN; the push uses the App token below
+      issues: write # comment on the PR
     steps:
       # needs to be able to trigger CI, as default token does not retrigger
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -300,8 +301,11 @@ jobs:
         with:
           app-id: ${{ secrets.CMD_BOT_APP_ID }}
           private-key: ${{ secrets.CMD_BOT_APP_KEY }}
+          permission-contents: write
 
-      - name: Checkout
+      # Pushes commits to the PR branch via the App token, so this checkout must
+      # persist credentials — artipacked is expected and safe here.
+      - name: Checkout # zizmor: ignore[artipacked]
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.generate_token.outputs.token }}
@@ -315,6 +319,8 @@ jobs:
           path: command-diff
 
       - name: Apply & Commit changes
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
           ls -lsa .
 
@@ -340,7 +346,7 @@ jobs:
 
             git add .
             git restore --staged Cargo.lock # ignore changes in Cargo.lock
-            git commit -m "Update from ${{ github.actor }} running command '$CMD'" || true
+            git commit -m "Update from $ACTOR running command '$CMD'" || true
 
             # Attempt to push changes
             if ! push_changes; then
@@ -362,10 +368,11 @@ jobs:
           SUBWEIGHT: "${{ needs.cmd.outputs.subweight }}"
           CMD_OUTPUT: "${{ needs.cmd.outputs.cmd_output }}"
           PR_NUM: ${{ github.event.inputs.pr_num }}
+          RUN_URL: ${{ needs.before-cmd.outputs.run_url }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            let runUrl = ${{ needs.before-cmd.outputs.run_url }};
+            let runUrl = process.env.RUN_URL || '';
             let subweight = process.env.SUBWEIGHT || '';
             let cmdOutput = process.env.CMD_OUTPUT || '';
             let cmd = process.env.CMD;
@@ -380,7 +387,7 @@ jobs:
               : '';
 
             github.rest.issues.createComment({
-              issue_number: ${{ env.PR_NUM }},
+              issue_number: Number(process.env.PR_NUM),
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Command "${cmd}" has finished ✅ [See logs here](${runUrl})${subweightCollapsed}${cmdOutputCollapsed}`
@@ -390,6 +397,8 @@ jobs:
     needs: [before-cmd, cmd, after-cmd]
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # comment on / react to the PR
     env:
       CMD_OUTPUT: "${{ needs.cmd.outputs.cmd_output }}"
       CMD: ${{ github.event.inputs.cmd }}
@@ -400,10 +409,12 @@ jobs:
         if: ${{ needs.cmd.result == 'failure' || needs.after-cmd.result == 'failure' ||
           needs.before-cmd.result == 'failure' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          JOB_URL: ${{ needs.before-cmd.outputs.job_url }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            let jobUrl = ${{ needs.before-cmd.outputs.job_url }};
+            let jobUrl = process.env.JOB_URL || '';
             let cmdOutput = process.env.CMD_OUTPUT;
             let cmd = process.env.CMD;
             let cmdOutputCollapsed = '';
@@ -412,7 +423,7 @@ jobs:
             }
 
             github.rest.issues.createComment({
-              issue_number: ${{ env.PR_NUM }},
+              issue_number: Number(process.env.PR_NUM),
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Command "${cmd}" has failed ❌! [See logs here](${jobUrl})${cmdOutputCollapsed}`
@@ -426,7 +437,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.reactions.createForIssueComment({
-              comment_id: ${{ env.COMMENT_ID }},
+              comment_id: Number(process.env.COMMENT_ID),
               owner: context.repo.owner,
               repo: context.repo.repo,
               content: 'confused'
@@ -440,7 +451,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.reactions.createForIssueComment({
-              comment_id: ${{ env.COMMENT_ID }},
+              comment_id: Number(process.env.COMMENT_ID),
               owner: context.repo.owner,
               repo: context.repo.repo,
               content: '+1'

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -4,16 +4,14 @@ on:
   issue_comment: # listen for comments on issues
     types: [created]
 
-permissions: # allow the action to comment in PR
-  contents: read
-  issues: write
-  pull-requests: write
-  actions: read
+# Least-privilege by default — each job grants only the scopes it needs.
+permissions: {}
 
 jobs:
   is-org-member:
     if: startsWith(github.event.comment.body, '/cmd')
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       member: ${{ steps.is-member.outputs.result }}
     steps:
@@ -23,18 +21,22 @@ jobs:
         with:
           app-id: ${{ secrets.CMD_BOT_APP_ID }}
           private-key: ${{ secrets.CMD_BOT_APP_KEY }}
+          permission-members: read
 
       - name: Check if user is a member of the organization
         id: is-member
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ORG: ${{ github.event.repository.owner.login }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           result-encoding: string
           script: |
             const fs = require("fs");
             try {
-              const org = '${{ github.event.repository.owner.login }}';
-              const username = '${{ github.event.comment.user.login }}';
+              const org = process.env.ORG;
+              const username = process.env.COMMENT_USER;
 
               const membership = await github.rest.orgs.checkMembershipForUser({
                   org: org,
@@ -58,6 +60,8 @@ jobs:
   acknowledge:
     if: ${{ startsWith(github.event.comment.body, '/cmd') }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Add reaction to triggered comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -73,6 +77,8 @@ jobs:
 
   clean:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Clean previous comments
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -112,6 +118,9 @@ jobs:
   get-pr-info:
     if: ${{ startsWith(github.event.comment.body, '/cmd') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       CMD: ${{ steps.get-comment.outputs.group2 }}
       pr-branch: ${{ steps.get-pr.outputs.pr_branch }}
@@ -127,8 +136,10 @@ jobs:
       # Get PR branch name, because the issue_comment event does not contain the PR branch name
       - name: Check if the issue is a PR
         id: check-pr
+        env:
+          PR_URL: ${{ github.event.issue.pull_request.url }}
         run: |
-          if [ -n "${{ github.event.issue.pull_request.url }}" ]; then
+          if [ -n "$PR_URL" ]; then
             echo "This is a pull request comment"
           else
             echo "This is not a pull request comment"
@@ -166,9 +177,14 @@ jobs:
     needs: [clean, get-pr-info]
     if: ${{ startsWith(github.event.comment.body, '/cmd') && contains(github.event.comment.body, '--help') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Save output of help
         id: help
@@ -181,6 +197,8 @@ jobs:
 
       - name: Comment PR (Help)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HELP_OUTPUT: ${{ steps.help.outputs.help }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -191,7 +209,7 @@ jobs:
               body: `<details><summary>Command help:</summary>
 
             \`\`\`
-            ${{ steps.help.outputs.help }}
+            ${process.env.HELP_OUTPUT}
             \`\`\`
 
             </details>`
@@ -226,12 +244,15 @@ jobs:
   set-image:
     needs: [clean, get-pr-info]
     if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(github.event.comment.body, '--help') }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/set-image.yml
 
   set-runner:
     needs: [get-pr-info, set-image]
     if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(github.event.comment.body, '--help') }}
     runs-on: ubuntu-latest
+    permissions: {}
     env:
       CMD: ${{ needs.get-pr-info.outputs.CMD }}
       DEFAULT_IMAGE: ${{ needs.set-image.outputs.CI_IMAGE }}
@@ -259,55 +280,20 @@ jobs:
           fi
 
       - name: Print outputs
+        env:
+          RUNNER: ${{ steps.set-image.outputs.RUNNER }}
+          IMAGE: ${{ steps.set-image.outputs.IMAGE }}
         run: |
-          echo "RUNNER=${{ steps.set-image.outputs.RUNNER }}"
-          echo "IMAGE=${{ steps.set-image.outputs.IMAGE }}"
-
-  check-pr-author:
-    runs-on: ubuntu-latest
-    outputs:
-      is_author: ${{ steps.check-author.outputs.result }}
-    steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.CMD_BOT_APP_ID }}
-          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
-
-      - name: Check if user is PR author
-        id: check-author
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          result-encoding: string
-          script: |
-            const commentUser = '${{ github.event.comment.user.login }}';
-            const prNumber = ${{ github.event.issue.number }};
-
-            try {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              const prAuthor = pr.data.user.login;
-              return commentUser === prAuthor ? 'true' : 'false';
-            } catch (error) {
-              console.error('Error checking PR author:', error);
-              return 'false';
-            }
+          echo "RUNNER=$RUNNER"
+          echo "IMAGE=$IMAGE"
 
   run-cmd-workflow:
-    needs: [set-runner, get-pr-info, is-org-member, check-pr-author]
+    needs: [set-runner, get-pr-info, is-org-member]
     runs-on: ubuntu-latest
-    # don't run on help; require commenter to be an org member or the PR author
-    if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(github.event.comment.body, '--help') && (needs.is-org-member.outputs.member == 'true' || needs.check-pr-author.outputs.is_author == 'true') }}
-    permissions: # run workflow
+    # don't run on help; require the commenter to be an org member
+    if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(github.event.comment.body, '--help') && needs.is-org-member.outputs.member == 'true' }}
+    permissions: # dispatch cmd-run.yml
       contents: read
-      issues: write
-      pull-requests: write
       actions: write
     env:
       CMD: ${{ needs.get-pr-info.outputs.CMD }}
@@ -316,12 +302,14 @@ jobs:
       IMAGE: ${{ needs.set-runner.outputs.IMAGE }}
       REPO: ${{ needs.get-pr-info.outputs.repo }}
       IS_ORG_MEMBER: ${{ needs.is-org-member.outputs.member }}
-      IS_PR_AUTHOR: ${{ needs.check-pr-author.outputs.is_author }}
       COMMENT_ID: ${{ github.event.comment.id }}
       PR_NUMBER: ${{ github.event.issue.number }}
+      IS_QUIET: ${{ contains(github.event.comment.body, '--quiet') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Start cmd with gh cli
         env:
@@ -335,7 +323,6 @@ jobs:
             -f pr_num="${PR_NUMBER}" \
             -f runner="${RUNNER}" \
             -f is_org_member="${IS_ORG_MEMBER}" \
-            -f is_pr_author="${IS_PR_AUTHOR}" \
             -f comment_id="${COMMENT_ID}" \
             -f image="${IMAGE}" \
-            -f is_quiet="${{ contains(github.event.comment.body, '--quiet') }}"
+            -f is_quiet="${IS_QUIET}"

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -22,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -74,6 +74,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   set-image:
     uses: ./.github/workflows/set-image.yml
@@ -29,6 +32,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -82,6 +87,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -103,7 +110,7 @@ jobs:
 
       - name: Download Polkadot SDK binaries
         if: steps.sdk-cache.outputs.cache-hit != 'true'
-        run: just polkadot_version=${{ env.POLKADOT_SDK_VERSION }} download-polkadot-sdk-binaries
+        run: just polkadot_version="$POLKADOT_SDK_VERSION" download-polkadot-sdk-binaries
 
       - name: Cache zombienet
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -114,7 +121,7 @@ jobs:
 
       - name: Download zombienet
         if: steps.zombienet-cache.outputs.cache-hit != 'true'
-        run: just zombienet_version=${{ env.ZOMBIENET_VERSION }} download-zombienet
+        run: just zombienet_version="$ZOMBIENET_VERSION" download-zombienet
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -198,11 +205,17 @@ jobs:
     runs-on: parity-large
     timeout-minutes: 60
     needs: [set-image, build]
+    # actions: write is required by the push-only "gh cache delete" step below.
+    permissions:
+      contents: read
+      actions: write
     container:
       image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -243,7 +256,7 @@ jobs:
 
       - name: Download Polkadot SDK binaries
         if: steps.sdk-cache.outputs.cache-hit != 'true'
-        run: just polkadot_version=${{ env.POLKADOT_SDK_VERSION }} download-polkadot-sdk-binaries
+        run: just polkadot_version="$POLKADOT_SDK_VERSION" download-polkadot-sdk-binaries
 
       - name: Log binary versions
         run: |
@@ -370,6 +383,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -391,7 +406,7 @@ jobs:
 
       - name: Download Polkadot SDK binaries
         if: steps.sdk-cache.outputs.cache-hit != 'true'
-        run: just polkadot_version=${{ env.POLKADOT_SDK_VERSION }} download-polkadot-sdk-binaries
+        run: just polkadot_version="$POLKADOT_SDK_VERSION" download-polkadot-sdk-binaries
 
       - name: Resolve chain-spec script
         run: |
@@ -524,6 +539,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -556,7 +573,7 @@ jobs:
 
       - name: Download Polkadot SDK binaries
         if: steps.sdk-cache.outputs.cache-hit != 'true'
-        run: just polkadot_version=${{ env.POLKADOT_SDK_VERSION }} download-polkadot-sdk-binaries
+        run: just polkadot_version="$POLKADOT_SDK_VERSION" download-polkadot-sdk-binaries
 
       # Restored before the artifact download so the cached target/ can't clobber
       # the freshly downloaded provider + wbuild. save-if false — only the build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Check provider-node version matches tag
         run: |
@@ -48,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Runtime config
         id: config
@@ -96,6 +100,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -149,6 +155,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> "$GITHUB_ENV"
@@ -200,6 +208,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -257,8 +267,9 @@ jobs:
 
           cat RELEASE_NOTES.md
 
+      # gh-release handles multi-asset uploads + the release body; intentional.
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # zizmor: ignore[superfluous-actions]
         with:
           name: ${{ needs.build-runtime.outputs.name }} ${{ github.ref_name }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
 
       # gh-release handles multi-asset uploads + the release body; intentional.
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # zizmor: ignore[superfluous-actions]
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 zizmor: ignore[superfluous-actions]
         with:
           name: ${{ needs.build-runtime.outputs.name }} ${{ github.ref_name }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,13 +267,17 @@ jobs:
 
           cat RELEASE_NOTES.md
 
-      # gh-release handles multi-asset uploads + the release body; intentional.
+      # Use the runner's preinstalled gh CLI rather than a third-party action;
+      # the job already holds contents: write. Tag defaults to github.ref_name.
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 zizmor: ignore[superfluous-actions]
-        with:
-          name: ${{ needs.build-runtime.outputs.name }} ${{ github.ref_name }}
-          files: |
-            release-assets/*.wasm
-            release-assets/storage-provider-node-*.tar.gz
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          RELEASE_NAME: ${{ needs.build-runtime.outputs.name }} ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --title "$RELEASE_NAME" \
+            --notes-file RELEASE_NOTES.md \
+            release-assets/*.wasm \
+            release-assets/storage-provider-node-*.tar.gz \
             release-assets/storage-provider-node-*.tar.gz.sha256
-          body_path: RELEASE_NOTES.md

--- a/.github/workflows/set-image.yml
+++ b/.github/workflows/set-image.yml
@@ -12,15 +12,19 @@ jobs:
     # This workaround sets the container image for each job using 'set-image' job output.
     # env variables don't work for PRs from forks, so we need to use outputs.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       CI_IMAGE: ${{ steps.set_image.outputs.CI_IMAGE }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
 
       - name: Set CI image output
         id: set_image
-        run: echo "CI_IMAGE=${{ env.CI_IMAGE }}" >> $GITHUB_OUTPUT
+        run: echo "CI_IMAGE=$CI_IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ui-checks.yml
+++ b/.github/workflows/ui-checks.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Detect UI changes
@@ -22,6 +25,8 @@ jobs:
       ui: ${{ steps.filter.outputs.ui }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
@@ -37,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -76,6 +83,8 @@ jobs:
             filter: provider-dashboard
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV
@@ -109,6 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load common environment variables via env file
         run: cat .github/env >> $GITHUB_ENV

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,48 @@
+name: Zizmor
+
+# Static analysis of the GitHub Actions workflows themselves. zizmor only parses
+# the workflow/action YAML — it never executes repo code — so it is safe to run
+# on fork PRs with a read-only token. Fails on any finding not explicitly
+# accepted in .github/zizmor.yml, keeping the CI hardening from regressing.
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  ZIZMOR_VERSION: 1.25.2
+
+jobs:
+  zizmor:
+    name: Audit workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Cache the compiled binary so only the first run pays the build cost.
+      - name: Cache zizmor
+        id: cache-zizmor
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cargo/bin/zizmor
+          key: zizmor-${{ env.ZIZMOR_VERSION }}-${{ runner.os }}
+
+      - name: Install zizmor
+        if: steps.cache-zizmor.outputs.cache-hit != 'true'
+        run: cargo install zizmor --version "$ZIZMOR_VERSION" --locked
+
+      - name: Audit .github/
+        run: zizmor --offline .github/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,21 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# Findings ignored here are deliberate, documented exceptions. Everything else
+# must stay clean: the `zizmor` CI workflow fails the build on any other finding.
+rules:
+  # The CI container image is resolved at runtime from .github/env (a trusted,
+  # committed file) via the set-image reusable workflow, and the cmd-bot image is
+  # the gated /cmd flow's input. Neither can be pinned to a digest in-line, and
+  # there are no other (pinnable) image refs in these files.
+  unpinned-images:
+    ignore:
+      - check.yml
+      - integration-tests.yml
+      - release.yml
+      - cmd-run.yml
+  # The release caches use release-specific keys (release-provider-{linux,macos})
+  # written only on tag builds (a trusted context); no lower-privilege workflow
+  # can poison them. Restore benefits the one-shot release builds.
+  cache-poisoning:
+    ignore:
+      - release.yml


### PR DESCRIPTION
Audited all github workflows with zizmor and fixed a bunch of issues. 179 findings -> 0 (17 documented exceptions).

- /cmd bot: org-members-only (dropped PR-author path), scoped the GitHub App tokens (members: read / contents: write, were full-installation), least-privilege per job.
- Minimal permissions: on all workflows; deploy-ui pages/id-token moved to its deploy job.
- Template-injection closed via env-indirection (workflows + 4 composite actions).
- persist-credentials: false on non-pushing checkouts; dependabot cooldown.
- New zizmor.yml CI gate + .github/zizmor.yml (keeps this from regressing).