### PR TITLE
fix(provider-node): deflake coordinator pause/stop startup race

### DIFF
--- a/provider-node/src/agreement_coordinator.rs
+++ b/provider-node/src/agreement_coordinator.rs
@@ -136,6 +136,11 @@ impl AgreementCoordinator {
 
         loop {
             tokio::select! {
+                // Prefer control commands over the poll tick: the interval's
+                // first tick fires immediately, so an unbiased select could
+                // service a poll before a Stop queued right after start().
+                biased;
+
                 cmd = command_rx.recv() => {
                     match cmd {
                         Some(AgreementCommand::Stop) | None => {

--- a/provider-node/src/challenge_responder.rs
+++ b/provider-node/src/challenge_responder.rs
@@ -221,6 +221,11 @@ impl ChallengeResponder {
 
         loop {
             tokio::select! {
+                // Prefer control commands over the poll tick: the interval's
+                // first tick fires immediately, so an unbiased select could
+                // service a poll before a Pause/Stop queued right after start().
+                biased;
+
                 cmd = command_rx.recv() => {
                     match cmd {
                         Some(ResponderCommand::Stop) | None => {

--- a/provider-node/src/checkpoint_coordinator.rs
+++ b/provider-node/src/checkpoint_coordinator.rs
@@ -254,6 +254,11 @@ impl CheckpointCoordinator {
 
         loop {
             tokio::select! {
+                // Prefer control commands over the poll tick: the interval's
+                // first tick fires immediately, so an unbiased select could
+                // service a poll before a Pause/Stop queued right after start().
+                biased;
+
                 cmd = command_rx.recv() => {
                     match cmd {
                         Some(CoordinatorCommand::Stop) | None => {

--- a/provider-node/src/replica_sync_coordinator.rs
+++ b/provider-node/src/replica_sync_coordinator.rs
@@ -326,6 +326,11 @@ impl ReplicaSyncCoordinator {
 
         loop {
             tokio::select! {
+                // Prefer control commands over the poll tick: the interval's
+                // first tick fires immediately, so an unbiased select could
+                // service a poll before a Pause/Stop queued right after start().
+                biased;
+
                 cmd = command_rx.recv() => {
                     match cmd {
                         Some(SyncCommand::Stop) | None => {


### PR DESCRIPTION
## Problem

`challenge::test_resume_after_pause` is flaky and failed on an unrelated CI run (e.g. the PR #158 hardening run):

```
challenge::test_resume_after_pause panicked at provider-node/tests/coordinators/challenge.rs:418:
assertion failed: mock.submitted.lock().unwrap().is_empty()
```

## Root cause

Each coordinator's `run_loop` does:

```rust
tokio::select! {
    cmd = command_rx.recv() => { ... }   // Pause / Stop / Resume
    _   = interval.tick()    => { ... }  // poll + auto-respond
}
```

`tokio::time::interval` fires its **first tick immediately**. So on the first loop iteration both arms are ready, and an unbiased `select!` picks one **at random**. A `Pause`/`Stop` queued right after `start()` could lose to that immediate tick — the loop then polls and submits once *before* the command takes effect, leaving `mock.submitted` non-empty and tripping the assertion ~50% of the time.

## Fix

Add `biased;` to the `select!` in all four coordinators (challenge, checkpoint, replica-sync, agreement) so control commands are polled before the timer tick. Pause/Stop now deterministically take effect before the first poll, while immediate-poll-on-start is preserved when no command is pending.

Applied to all four because they're copies of the same loop with the same latent race; only the challenge test currently asserts in a way that catches it.

## Verification

- `cargo test -p storage-provider-node --test coordinators` → **39/39 pass**
- previously-flaky test looped → **50/50 pass** (was ~50% before)
- `cargo +nightly fmt --all` → clean
- `cargo clippy -p storage-provider-node --all-targets --all-features -- -D warnings` → clean