### PR TITLE
Make is_pr_author optional in /cmd

### DIFF
--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -21,10 +21,6 @@ on:
       is_org_member:
         description: "Is the user an org member"
         required: true
-      is_pr_author:
-        description: "Is the user the PR author"
-        required: false
-        default: "false"
       repo:
         description: "Repository to use"
         required: true
@@ -298,7 +294,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate_token
         with:
-          app-id: ${{ secrets.CMD_BOT_APP_ID }}
+          client-id: ${{ secrets.CMD_BOT_APP_ID }}
           private-key: ${{ secrets.CMD_BOT_APP_KEY }}
 
       - name: Checkout

--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -23,7 +23,8 @@ on:
         required: true
       is_pr_author:
         description: "Is the user the PR author"
-        required: true
+        required: false
+        default: "false"
       repo:
         description: "Repository to use"
         required: true
@@ -170,7 +171,6 @@ jobs:
         id: cmd
         env:
           IS_ORG_MEMBER: ${{ github.event.inputs.is_org_member }}
-          IS_PR_AUTHOR: ${{ github.event.inputs.is_pr_author }}
           RUNNER: ${{ github.event.inputs.runner }}
           IMAGE: ${{ github.event.inputs.image }}
         run: |


### PR DESCRIPTION
The /cmd flow dispatches cmd-run.yml with `gh workflow run --ref cmd-bot`, so workflow_dispatch inputs are validated against this branch. After the PR-author authorization path was dropped from cmd.yml (in #158), it stopped sending is_pr_author, which 422'd the dispatch ("Required input 'is_pr_author' not provided") because the input was required here.

Make it optional with a default and drop the now-dead IS_PR_AUTHOR env var (the Run cmd step never read it). Keeping the input declared rather than removing it avoids an "Unexpected inputs provided" 422 from cmd.yml copies that still pass the flag, so the two branches can be updated in any order.