### PR TITLE
S3 UI [1/5]: Scaffold, S3 client, state layer, UI primitives

### DIFF
--- a/runtimes/web3-storage-paseo/src/lib.rs
+++ b/runtimes/web3-storage-paseo/src/lib.rs
@@ -184,9 +184,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: Cow::Borrowed("paseo-web3-storage-runtime"),
     authoring_version: 1,
     // Encodes the runtime semver: major * 1_000_000 + minor * 1_000 + patch.
-    // 0.2.0 -> 0_002_000. Must stay > the deployed value so the upgrade is
+    // 0.2.0 -> 2_000. Must stay > the deployed value so the upgrade is
     // accepted and migrations run (previous release was `1`).
-    spec_version: 0_002_000,
+    spec_version: 2_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/user-interfaces/pnpm-lock.yaml
+++ b/user-interfaces/pnpm-lock.yaml
@@ -374,6 +374,97 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0))
 
+  s3-ui:
+    dependencies:
+      '@polkadot-api/descriptors':
+        specifier: workspace:*
+        version: link:../shared/papi/.papi/descriptors
+      '@polkadot-api/substrate-bindings':
+        specifier: ^0.20.3
+        version: 0.20.3
+      '@polkadot-labs/hdkd':
+        specifier: ^0.0.11
+        version: 0.0.11
+      '@polkadot-labs/hdkd-helpers':
+        specifier: ^0.0.13
+        version: 0.0.13
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.6
+        version: 2.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.6
+        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.6
+        version: 2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.1
+        version: 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.6
+        version: 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-rxjs/core':
+        specifier: ^0.10.7
+        version: 0.10.8(react@19.2.7)(rxjs@7.8.2)
+      '@web3-storage/network-config':
+        specifier: workspace:*
+        version: link:../shared/network-config
+      '@web3-storage/network-picker':
+        specifier: workspace:*
+        version: link:../shared/network-picker
+      '@web3-storage/papi':
+        specifier: workspace:*
+        version: link:../shared/papi
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.474.0
+        version: 0.474.0(react@19.2.7)
+      polkadot-api:
+        specifier: ^2.1.6
+        version: 2.1.6(esbuild@0.28.0)(rxjs@7.8.2)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.17.0
+        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
+      tailwind-merge:
+        specifier: ^3.0.1
+        version: 3.6.0
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.0.0
+        version: 4.3.0(vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@types/react':
+        specifier: ^19.1.8
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.6
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.7.0(vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^6.2.2
+        version: 6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
+
   shared/network-config: {}
 
   shared/network-picker:
@@ -481,6 +572,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -501,6 +596,18 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -536,16 +643,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.0':
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.0':
@@ -554,16 +679,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.0':
     resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
@@ -572,10 +715,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -584,10 +739,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
@@ -596,10 +763,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
@@ -608,10 +787,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -620,10 +811,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.0':
@@ -632,16 +835,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.0':
     resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.0':
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.0':
@@ -650,10 +871,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.0':
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -662,11 +895,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.0':
     resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
@@ -674,16 +919,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.0':
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.0':
@@ -794,6 +1057,10 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/curves@1.8.2':
+    resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -805,6 +1072,10 @@ packages:
   '@noble/curves@2.2.0':
     resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@1.7.2':
+    resolution: {integrity: sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -988,8 +1259,17 @@ packages:
     peerDependencies:
       rxjs: '>=7.8.0'
 
+  '@polkadot-labs/hdkd-helpers@0.0.11':
+    resolution: {integrity: sha512-qPlWqC3NNV/2NYc5GEy+Ovi4UBAgkMGvMfyiYuj2BQN4lW59Q1T9coNx0Yp6XzsnJ1ddaF9PWaUtxj3LdM0IDw==}
+
+  '@polkadot-labs/hdkd-helpers@0.0.13':
+    resolution: {integrity: sha512-70Py+++jOvmSO6ncANHnDK70QA1JNCDE0EifqNApcPC6XWR/tNhOxxgqo6PqKF0gwgNi0u+mMa0dzRERu3PP9Q==}
+
   '@polkadot-labs/hdkd-helpers@0.0.30':
     resolution: {integrity: sha512-qWmmD6ayj14RenDuDFfjF3sHS7ObqPzwIIMPcSVoDeKFSeQV7RY0HwyhC5CG4i6FoguMzak2dbtjYpNN5XQiwQ==}
+
+  '@polkadot-labs/hdkd@0.0.11':
+    resolution: {integrity: sha512-1s375PlIup6cV7EYZ1+Y1eLGLQlYnv7Gdvo20aA5PzXH2VskKHSOOgXH1t1umJIAG8J0pGXlCDG0kNc7nm8+ww==}
 
   '@polkadot-labs/hdkd@0.0.28':
     resolution: {integrity: sha512-LpdqtQRpcgZQ5Mr8J0ddMA5ZufsbI4W3KuJkVdoYMnSmWs4179LigDb1rTYAOtyCg2jWUjf7rWP0mGxQQvNrHw==}
@@ -1647,6 +1927,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -1931,6 +2214,18 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/bn.js@5.2.0':
     resolution: {integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==}
 
@@ -2021,6 +2316,12 @@ packages:
   '@typescript-eslint/visitor-keys@8.60.1':
     resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -2208,6 +2509,11 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
@@ -2569,6 +2875,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.474.0:
+    resolution: {integrity: sha512-CmghgHkh0OJNmxGKWc0qfPJCYHASPMVSyGY8fj3xgk4v84ItqDg64JNKFZn5hC6E0vHi6gxnbCgwhyVB09wQtA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lucide-react@1.17.0:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
@@ -2576,6 +2887,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  micro-sr25519@0.1.3:
+    resolution: {integrity: sha512-Tw1I3Yjq9XySsU3hsgPVkQTG3NIje070VUWtT4tb9d1tVwQqpCIBH4SM5h4Mxp2Ua4PUyPsot2F40eyJ0QnzTg==}
+    deprecated: Switch to "@scure/sr25519" for security updates
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2734,6 +3049,10 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3038,6 +3357,46 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3260,6 +3619,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
@@ -3274,6 +3635,16 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/template@7.29.7':
     dependencies:
@@ -3324,79 +3695,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
@@ -3506,6 +3955,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@noble/curves@1.8.2':
+    dependencies:
+      '@noble/hashes': 1.7.2
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -3517,6 +3970,8 @@ snapshots:
   '@noble/curves@2.2.0':
     dependencies:
       '@noble/hashes': 2.2.0
+
+  '@noble/hashes@1.7.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -3861,6 +4316,22 @@ snapshots:
       '@polkadot-api/utils': 0.4.0
       rxjs: 7.8.2
 
+  '@polkadot-labs/hdkd-helpers@0.0.11':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      micro-sr25519: 0.1.3
+      scale-ts: 1.6.1
+
+  '@polkadot-labs/hdkd-helpers@0.0.13':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      micro-sr25519: 0.1.3
+      scale-ts: 1.6.1
+
   '@polkadot-labs/hdkd-helpers@0.0.30':
     dependencies:
       '@noble/curves': 2.2.0
@@ -3868,6 +4339,10 @@ snapshots:
       '@scure/base': 2.2.0
       '@scure/sr25519': 1.0.0
       scale-ts: 1.6.1
+
+  '@polkadot-labs/hdkd@0.0.11':
+    dependencies:
+      '@polkadot-labs/hdkd-helpers': 0.0.11
 
   '@polkadot-labs/hdkd@0.0.28':
     dependencies:
@@ -4629,6 +5104,8 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.0':
@@ -4822,6 +5299,13 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
+  '@tailwindcss/vite@4.3.0(vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
+
   '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
@@ -4833,6 +5317,27 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@types/bn.js@5.2.0':
     dependencies:
@@ -4955,6 +5460,18 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0))':
     dependencies:
@@ -5110,6 +5627,35 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -5451,6 +5997,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@0.474.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   lucide-react@1.17.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -5458,6 +6008,11 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  micro-sr25519@0.1.3:
+    dependencies:
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
 
   mimic-function@5.0.1: {}
 
@@ -5650,6 +6205,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -5974,6 +6531,20 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
 
   vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0):
     dependencies:

--- a/user-interfaces/pnpm-workspace.yaml
+++ b/user-interfaces/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - provider
   - console-ui
   - drive-ui
+  - s3-ui
 
 allowBuilds:
   esbuild: true

--- a/user-interfaces/s3-ui/index.html
+++ b/user-interfaces/s3-ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/s3-icon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web3 Storage — S3</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/user-interfaces/s3-ui/package.json
+++ b/user-interfaces/s3-ui/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@web3-storage/s3-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@polkadot-api/descriptors": "workspace:*",
+    "@polkadot-api/substrate-bindings": "^0.20.3",
+    "@polkadot-labs/hdkd": "^0.0.11",
+    "@polkadot-labs/hdkd-helpers": "^0.0.13",
+    "@radix-ui/react-context-menu": "^2.2.6",
+    "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-dropdown-menu": "^2.1.6",
+    "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-toast": "^1.2.6",
+    "@react-rxjs/core": "^0.10.7",
+    "@web3-storage/network-config": "workspace:*",
+    "@web3-storage/network-picker": "workspace:*",
+    "@web3-storage/papi": "workspace:*",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.474.0",
+    "polkadot-api": "^2.1.6",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.17.0",
+    "rxjs": "^7.8.2",
+    "tailwind-merge": "^3.0.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.4.1",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.3",
+    "vite": "^6.2.2"
+  }
+}

--- a/user-interfaces/s3-ui/src/App.tsx
+++ b/user-interfaces/s3-ui/src/App.tsx
@@ -1,0 +1,12 @@
+import { Toaster } from "@/components/ui/toaster";
+
+export default function App() {
+  return (
+    <>
+      <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
+        <p className="text-muted-foreground">S3 UI</p>
+      </div>
+      <Toaster />
+    </>
+  );
+}

--- a/user-interfaces/s3-ui/src/app.css
+++ b/user-interfaces/s3-ui/src/app.css
@@ -1,0 +1,34 @@
+@import "tailwindcss";
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #0f172a;
+  --color-card: #f8fafc;
+  --color-card-foreground: #0f172a;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #0f172a;
+  --color-primary: #4f46e5;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #f1f5f9;
+  --color-secondary-foreground: #0f172a;
+  --color-muted: #f1f5f9;
+  --color-muted-foreground: #64748b;
+  --color-accent: #f1f5f9;
+  --color-accent-foreground: #0f172a;
+  --color-destructive: #dc2626;
+  --color-destructive-foreground: #ffffff;
+  --color-border: #e2e8f0;
+  --color-input: #e2e8f0;
+  --color-ring: #4f46e5;
+  --radius: 0.5rem;
+}
+
+body {
+  @apply bg-background text-foreground;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+* {
+  @apply border-border;
+}

--- a/user-interfaces/s3-ui/src/components/ui/button.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/user-interfaces/s3-ui/src/components/ui/card.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/card.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/user-interfaces/s3-ui/src/components/ui/context-menu.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/context-menu.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { cn } from "@/lib/utils";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+const ContextMenuContent = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+};

--- a/user-interfaces/s3-ui/src/components/ui/dialog.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/dialog.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/user-interfaces/s3-ui/src/components/ui/dropdown-menu.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+};

--- a/user-interfaces/s3-ui/src/components/ui/input.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/user-interfaces/s3-ui/src/components/ui/progress.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/progress.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+
+interface ProgressProps {
+  value: number;
+  className?: string;
+}
+
+export function Progress({ value, className }: ProgressProps) {
+  return (
+    <div className={cn("relative h-2 w-full overflow-hidden rounded-full bg-secondary", className)}>
+      <div
+        className="h-full bg-primary transition-all duration-300 ease-in-out rounded-full"
+        style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+      />
+    </div>
+  );
+}

--- a/user-interfaces/s3-ui/src/components/ui/toaster.tsx
+++ b/user-interfaces/s3-ui/src/components/ui/toaster.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+const Toast = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold [&+div]:text-xs", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+// Simple toast store
+let toastCount = 0;
+const toastListeners: Set<() => void> = new Set();
+let toasts: Array<{
+  id: string;
+  title?: string;
+  description?: string;
+  variant?: "default" | "destructive";
+}> = [];
+
+function addToast(t: Omit<(typeof toasts)[0], "id">) {
+  const id = String(toastCount++);
+  toasts = [...toasts, { ...t, id }];
+  toastListeners.forEach((l) => l());
+  setTimeout(() => removeToast(id), 5000);
+}
+
+function removeToast(id: string) {
+  toasts = toasts.filter((t) => t.id !== id);
+  toastListeners.forEach((l) => l());
+}
+
+export function toast(props: {
+  title?: string;
+  description?: string;
+  variant?: "default" | "destructive";
+}) {
+  addToast(props);
+}
+
+export function Toaster() {
+  const [, setUpdate] = React.useState(0);
+
+  React.useEffect(() => {
+    const listener = () => setUpdate((u) => u + 1);
+    toastListeners.add(listener);
+    return () => {
+      toastListeners.delete(listener);
+    };
+  }, []);
+
+  return (
+    <ToastProvider>
+      {toasts.map((t) => (
+        <Toast key={t.id} variant={t.variant}>
+          <div className="grid gap-1">
+            {t.title && <ToastTitle>{t.title}</ToastTitle>}
+            {t.description && (
+              <ToastDescription>{t.description}</ToastDescription>
+            )}
+          </div>
+          <ToastClose onClick={() => removeToast(t.id)} />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/user-interfaces/s3-ui/src/lib/crypto.ts
+++ b/user-interfaces/s3-ui/src/lib/crypto.ts
@@ -1,0 +1,50 @@
+/**
+ * PAPI-native crypto helpers: seed -> sr25519 keypair, SS58 encode/validate.
+ *
+ * Replaces @polkadot/keyring + @polkadot/util-crypto. URI parsing mirrors
+ * @polkadot/keyring's addFromUri so dev-account seeds (//Alice etc.) keep
+ * producing identical addresses.
+ */
+import { sr25519CreateDerive } from "@polkadot-labs/hdkd";
+import {
+  DEV_PHRASE,
+  entropyToMiniSecret,
+  mnemonicToEntropy,
+} from "@polkadot-labs/hdkd-helpers";
+import { getSs58AddressInfo } from "@polkadot-api/substrate-bindings";
+
+// SS58 encoding (prefix + helper) lives in the shared PAPI package so every UI
+// renders addresses with the same, runtime-derived prefix.
+export { toSs58 } from "@web3-storage/papi";
+
+export interface Keypair {
+  publicKey: Uint8Array;
+  sign(input: Uint8Array): Uint8Array;
+}
+
+export function seedToKeypair(seed: string): Keypair {
+  const trimmed = seed.trim();
+  let mnemonic: string;
+  let derivationPath: string;
+  if (trimmed.startsWith("//")) {
+    mnemonic = DEV_PHRASE;
+    derivationPath = trimmed;
+  } else {
+    const sepIdx = trimmed.indexOf("//");
+    if (sepIdx === -1) {
+      mnemonic = trimmed;
+      derivationPath = "";
+    } else {
+      mnemonic = trimmed.slice(0, sepIdx).trim();
+      derivationPath = trimmed.slice(sepIdx);
+    }
+  }
+  const entropy = mnemonicToEntropy(mnemonic);
+  const miniSecret = entropyToMiniSecret(entropy);
+  const derive = sr25519CreateDerive(miniSecret);
+  return derive(derivationPath);
+}
+
+export function isValidSs58(address: string): boolean {
+  return getSs58AddressInfo(address).isValid;
+}

--- a/user-interfaces/s3-ui/src/lib/encryption.ts
+++ b/user-interfaces/s3-ui/src/lib/encryption.ts
@@ -1,0 +1,118 @@
+/**
+ * Client-side encryption using WebCrypto AES-256-GCM.
+ *
+ * Wire format: [0x02][12-byte IV][ciphertext + 16-byte GCM tag]
+ *
+ * Version bytes:
+ *   0x01 = XChaCha20-Poly1305 (Rust native)
+ *   0x02 = AES-256-GCM (browser WebCrypto)
+ */
+
+const VERSION_AES_GCM = 0x02;
+const IV_SIZE = 12;
+const TAG_SIZE = 16;
+
+/** Overhead added by encryption: 1 (version) + 12 (IV) + 16 (tag). */
+export const ENCRYPTION_OVERHEAD = 1 + IV_SIZE + TAG_SIZE;
+
+/**
+ * Encryption key wrapping a WebCrypto CryptoKey for AES-256-GCM.
+ */
+export class EncryptionKey {
+  private cryptoKey: CryptoKey;
+
+  private constructor(cryptoKey: CryptoKey) {
+    this.cryptoKey = cryptoKey;
+  }
+
+  /** Import a raw 32-byte key. */
+  static async fromBytes(rawKey: Uint8Array): Promise<EncryptionKey> {
+    if (rawKey.length !== 32) {
+      throw new Error(`Encryption key must be 32 bytes, got ${rawKey.length}`);
+    }
+    const cryptoKey = await crypto.subtle.importKey(
+      "raw",
+      // TS 6.0 types `Uint8Array` as `Uint8Array<ArrayBufferLike>`, but Web Crypto
+      // wants an `ArrayBuffer`-backed view; browser buffers are never shared.
+      rawKey as Uint8Array<ArrayBuffer>,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt", "decrypt"],
+    );
+    return new EncryptionKey(cryptoKey);
+  }
+
+  /** Generate a random 256-bit key. Returns the key and its raw bytes. */
+  static async generate(): Promise<{ encryptionKey: EncryptionKey; rawKey: Uint8Array }> {
+    const rawKey = new Uint8Array(32);
+    crypto.getRandomValues(rawKey);
+    const encryptionKey = await EncryptionKey.fromBytes(rawKey);
+    return { encryptionKey, rawKey };
+  }
+
+  /** Encrypt plaintext into `[0x02][IV][ciphertext+tag]`. */
+  async encrypt(plaintext: Uint8Array): Promise<Uint8Array> {
+    const iv = new Uint8Array(IV_SIZE);
+    crypto.getRandomValues(iv);
+
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      this.cryptoKey,
+      plaintext as Uint8Array<ArrayBuffer>,
+    );
+
+    const out = new Uint8Array(1 + IV_SIZE + ciphertext.byteLength);
+    out[0] = VERSION_AES_GCM;
+    out.set(iv, 1);
+    out.set(new Uint8Array(ciphertext), 1 + IV_SIZE);
+    return out;
+  }
+
+  /** Decrypt data produced by `encrypt()`. */
+  async decrypt(data: Uint8Array): Promise<Uint8Array> {
+    const minLen = 1 + IV_SIZE + TAG_SIZE;
+    if (data.length < minLen) {
+      throw new Error(
+        `Encrypted data too short: ${data.length} bytes, minimum ${minLen}`,
+      );
+    }
+
+    const version = data[0]!;
+    if (version !== VERSION_AES_GCM) {
+      throw new Error(
+        `Unknown encryption version: 0x${version.toString(16).padStart(2, "0")}`,
+      );
+    }
+
+    const iv = data.slice(1, 1 + IV_SIZE);
+    const ciphertext = data.slice(1 + IV_SIZE);
+
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv },
+      this.cryptoKey,
+      ciphertext,
+    );
+
+    return new Uint8Array(plaintext);
+  }
+}
+
+/** Parse a hex string (with or without 0x prefix) into bytes. */
+export function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new Error("Invalid hex string length");
+  }
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/** Encode bytes as a hex string (no 0x prefix). */
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/user-interfaces/s3-ui/src/lib/s3-client.ts
+++ b/user-interfaces/s3-ui/src/lib/s3-client.ts
@@ -1,0 +1,703 @@
+/**
+ * S3 Client — wraps S3Registry pallet + StorageProvider pallet + provider HTTP
+ * endpoints. Ported from console-ui's StorageClient, restructured to match
+ * drive-ui's DriveClient class pattern (stateless w.r.t. connection).
+ */
+
+import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPayload } from "polkadot-api";
+import { parachain } from "@polkadot-api/descriptors";
+import { resolveProviderEndpoint, toSs58, type ParachainApi } from "@web3-storage/papi";
+
+export type Signer = PolkadotSigner;
+
+const HTTP_RETRY_ATTEMPTS = 3;
+const HTTP_RETRY_BASE_MS = 250;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface BucketInfo {
+  s3BucketId: bigint;
+  name: string;
+  layer0BucketId: bigint;
+  owner: string;
+  createdAt: bigint;
+}
+
+export interface S3ObjectInfo {
+  key: string;
+  size: number;
+  lastModified: number;
+  etag: string;
+}
+
+export interface UploadResult {
+  cid: string;
+  size: number;
+}
+
+export interface SignedTerms {
+  terms: {
+    owner: string;
+    max_bytes: number | bigint;
+    duration: number;
+    price_per_byte: number | bigint;
+    valid_until: number;
+    nonce: number | bigint;
+    replica_params: unknown | null;
+    bucket_id: bigint | null;
+  };
+  signature: string;
+}
+
+export interface NegotiateRequest {
+  owner: string;
+  max_bytes: number | bigint;
+  duration: number;
+  price_per_byte: number | bigint;
+  replica_params: unknown | null;
+  bucket_id?: bigint | null;
+}
+
+export interface AvailableProvider {
+  account: string;
+  multiaddr: string;
+  stake: bigint;
+  availableCapacity: bigint;
+  maxCapacity: bigint;
+  pricePerByte: bigint;
+  minDuration: number;
+  maxDuration: number;
+  acceptingPrimary: boolean;
+  agreementsTotal: number;
+}
+
+export interface MatchingProviders extends AvailableProvider {
+  matchScore: number;
+  partialReason: string;
+  committedBytes: bigint;
+  replicaSyncPrice?: bigint;
+  acceptingExtensions: boolean;
+  registeredAt: number;
+  agreementsExtended: number;
+  agreementsNotExtended: number;
+  agreementsBurned: number;
+  challengesReceived: number;
+  challengesFailed: number;
+}
+
+export type MemberRole = "Admin" | "Writer" | "Reader";
+
+export interface BucketMember {
+  account: string;
+  role: MemberRole;
+}
+
+export interface CheckpointInfo {
+  mmrRoot: string;
+  startSeq: bigint;
+  leafCount: bigint;
+  checkpointBlock: number;
+}
+
+export interface CheckpointDuty {
+  bucketId: number;
+  mmrRoot: string;
+  startSeq: number;
+  leafCount: number;
+  ready: boolean;
+}
+
+export interface QueryMatchingProvidersParams {
+  query: {
+    bytesNeeded: bigint;
+    minDuration: number;
+    maxPricePerByte: bigint;
+    primaryOnly: boolean;
+  };
+  limit: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof DOMException &&
+    (err.name === "AbortError" || err.code === DOMException.ABORT_ERR)
+  );
+}
+
+function isRetryableHttpError(status: number | null): boolean {
+  if (status === null) return true;
+  return status >= 500 && status < 600;
+}
+
+async function httpFetch(
+  url: string,
+  init: RequestInit & { signal?: AbortSignal } = {},
+): Promise<Response> {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < HTTP_RETRY_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, init);
+      if (res.ok || !isRetryableHttpError(res.status)) return res;
+      lastError = new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
+    } catch (err) {
+      if (isAbortError(err)) throw err;
+      lastError = err;
+    }
+    if (attempt < HTTP_RETRY_ATTEMPTS - 1) {
+      await sleep(HTTP_RETRY_BASE_MS * Math.pow(2, attempt));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("HTTP request failed");
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const out = new Uint8Array(h.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// MultiSignature SCALE variant order from sp_runtime.
+const MULTI_SIGNATURE_VARIANT: Record<number, string> = {
+  0: "Ed25519",
+  1: "Sr25519",
+  2: "Ecdsa",
+  3: "Eth",
+};
+
+export function buildSignedTermsArgs(
+  providerAccount: string,
+  signed: SignedTerms,
+) {
+  const sigBytes = hexToBytes(signed.signature);
+  if (sigBytes.length < 1) {
+    throw new Error("signature too short to contain a MultiSignature variant byte");
+  }
+  const variantByte = sigBytes[0]!;
+  const variantName = MULTI_SIGNATURE_VARIANT[variantByte];
+  if (!variantName) {
+    throw new Error(`unknown MultiSignature variant byte: ${variantByte}`);
+  }
+  const sigPayloadHex =
+    "0x" +
+    Array.from(sigBytes.slice(1))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sig = Enum(variantName as any, sigPayloadHex);
+
+  const t = signed.terms;
+  const terms = {
+    owner: t.owner,
+    max_bytes: BigInt(t.max_bytes),
+    duration: t.duration,
+    price_per_byte: BigInt(t.price_per_byte),
+    valid_until: t.valid_until,
+    nonce: BigInt(t.nonce),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    replica_params: (t.replica_params ?? undefined) as any,
+    bucket_id: t.bucket_id ? BigInt(t.bucket_id) : undefined,
+  };
+  return { provider: providerAccount, terms, sig };
+}
+
+export function parseMultiaddrToHttp(multiaddr: string): string | null {
+  const parts = multiaddr.split("/").filter(Boolean);
+  let host: string | null = null;
+  let port: string | null = null;
+
+  for (let i = 0; i < parts.length; i++) {
+    const seg = parts[i];
+    const next = parts[i + 1];
+    if (!next) continue;
+
+    if ((seg === "ip4" || seg === "ip6" || seg === "dns4" || seg === "dns6") && host === null) {
+      host = seg.startsWith("ip6") ? `[${next}]` : next;
+    }
+    if (seg === "tcp" && port === null) {
+      port = next;
+    }
+    if (host !== null && port !== null) break;
+  }
+
+  if (host && port) return `http://${host}:${port}`;
+  return null;
+}
+
+export async function negotiateTerms(
+  providerUrl: string,
+  request: NegotiateRequest,
+): Promise<SignedTerms> {
+  const res = await fetch(`${providerUrl.replace(/\/$/, "")}/negotiate`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(request, (_k, v) =>
+      typeof v === "bigint" ? v.toString() : v,
+    ),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`/negotiate failed: ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
+function decodeName(name: unknown): string {
+  if (name == null) return "";
+  try {
+    if (typeof name === "string") return name;
+    if (typeof (name as any).asText === "function") return (name as any).asText();
+    return new TextDecoder().decode(name as Uint8Array);
+  } catch {
+    return "";
+  }
+}
+
+// ── S3Client class ────────────────────────────────────────────────────────────
+
+export class S3Client {
+  private api: ParachainApi | null = null;
+  private signer: Signer | null = null;
+  private signerAddress: string | null = null;
+  private keypair: import("@/lib/crypto").Keypair | null = null;
+  private providerUrlCache = new Map<string, string>();
+
+  setApi(api: ParachainApi | null): void {
+    if (api !== this.api) {
+      this.providerUrlCache.clear();
+    }
+    this.api = api;
+  }
+
+  setSigner(signer: Signer | null, address: string | null): void {
+    this.signer = signer;
+    this.signerAddress = address;
+  }
+
+  setKeypair(keypair: import("@/lib/crypto").Keypair | null): void {
+    this.keypair = keypair;
+  }
+
+  hasApi(): boolean {
+    return this.api !== null;
+  }
+
+  hasSigner(): boolean {
+    return this.signer !== null && this.signerAddress !== null;
+  }
+
+  getSignerAddress(): string | null {
+    return this.signerAddress;
+  }
+
+  private requireApi(): ParachainApi {
+    if (!this.api) throw new Error("Not connected to chain");
+    return this.api;
+  }
+
+  private requireSigner(): { signer: Signer; address: string } {
+    if (!this.signer || !this.signerAddress) throw new Error("Signer not set");
+    return { signer: this.signer, address: this.signerAddress };
+  }
+
+  // ── Tx submission ─────────────────────────────────────────────────────────
+
+  private async submit(tx: Transaction): Promise<TxFinalizedPayload> {
+    const { signer } = this.requireSigner();
+    const result = await tx.signAndSubmit(signer);
+    if (!result.ok) {
+      const err = JSON.stringify(result.dispatchError, (_k, v) =>
+        typeof v === "bigint" ? v.toString() : v,
+      );
+      throw new Error(`Transaction failed on-chain: ${err}`);
+    }
+    return result;
+  }
+
+  // ── Provider resolution ───────────────────────────────────────────────────
+
+  async getProviderUrl(bucketId: bigint): Promise<string> {
+    const key = bucketId.toString();
+    const cached = this.providerUrlCache.get(key);
+    if (cached) return cached;
+    const url = await resolveProviderEndpoint(this.requireApi(), bucketId);
+    this.providerUrlCache.set(key, url);
+    return url;
+  }
+
+  invalidateProviderUrl(bucketId: bigint): void {
+    this.providerUrlCache.delete(bucketId.toString());
+  }
+
+  // ── S3 Bucket operations (on-chain) ─────────────────────────────────────
+
+  async createBucket(
+    name: string,
+    providerAccount: string,
+    providerUrl: string,
+    signed: SignedTerms,
+  ): Promise<BucketInfo> {
+    const api = this.requireApi();
+    const { address } = this.requireSigner();
+
+    const tx = api.tx.S3Registry.create_s3_bucket({
+      name: Binary.fromText(name),
+      ...buildSignedTermsArgs(providerAccount, signed),
+    });
+
+    const result = await this.submit(tx);
+
+    const created = api.event.S3Registry.S3BucketCreated.filter(result.events);
+    if (created.length === 0) {
+      // Fallback: query buckets for the latest
+      const buckets = await this.listBuckets();
+      if (buckets.length > 0) {
+        const latest = buckets[buckets.length - 1]!;
+        this.providerUrlCache.set(latest.layer0BucketId.toString(), providerUrl);
+        return latest;
+      }
+      throw new Error(
+        "S3BucketCreated event not found. The runtime descriptor may be stale — run: pnpm papi:generate",
+      );
+    }
+    const { s3_bucket_id, layer0_bucket_id } = created[0]!.payload;
+
+    this.providerUrlCache.set(layer0_bucket_id.toString(), providerUrl);
+
+    return {
+      s3BucketId: s3_bucket_id,
+      name,
+      layer0BucketId: layer0_bucket_id,
+      owner: address,
+      createdAt: 0n,
+    };
+  }
+
+  async listBuckets(): Promise<BucketInfo[]> {
+    const api = this.requireApi();
+    const { address } = this.requireSigner();
+
+    const bucketIds = await api.query.S3Registry.UserBuckets.getValue(address);
+    if (bucketIds.length === 0) return [];
+
+    const buckets: BucketInfo[] = [];
+    for (const s3BucketId of bucketIds) {
+      const bucket = await api.query.S3Registry.S3Buckets.getValue(s3BucketId);
+      if (!bucket) continue;
+      buckets.push({
+        s3BucketId,
+        name: decodeName(bucket.name),
+        layer0BucketId: bucket.layer0_bucket_id,
+        owner: bucket.owner,
+        createdAt: BigInt(bucket.created_at ?? 0),
+      });
+    }
+    return buckets;
+  }
+
+  async deleteBucket(s3BucketId: bigint): Promise<void> {
+    const api = this.requireApi();
+    const tx = api.tx.S3Registry.delete_s3_bucket({ s3_bucket_id: s3BucketId });
+    await this.submit(tx);
+  }
+
+  // ── S3 Object operations (HTTP) ─────────────────────────────────────────
+
+  private signRequest(method: string, bucketId: bigint): Record<string, string> {
+    if (!this.keypair) return {};
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const message = `web3storage:${method}:${Number(bucketId)}:${timestamp}`;
+    const msgBytes = new TextEncoder().encode(message);
+    const sig = this.keypair.sign(msgBytes);
+    const pubHex = bytesToHex(this.keypair.publicKey);
+    const sigHex = bytesToHex(sig);
+    return { Authorization: `Web3Storage ${pubHex}:${sigHex}:${timestamp}` };
+  }
+
+  async putObject(
+    bucketId: bigint,
+    key: string,
+    data: Uint8Array,
+    options?: { signal?: AbortSignal },
+  ): Promise<UploadResult> {
+    const providerUrl = await this.getProviderUrl(bucketId);
+    const params = new URLSearchParams({ key });
+    const headers: Record<string, string> = {
+      "Content-Type": "application/octet-stream",
+      ...this.signRequest("PUT", bucketId),
+    };
+    const response = await httpFetch(
+      `${providerUrl}/s3/${Number(bucketId)}/object?${params.toString()}`,
+      {
+        method: "PUT",
+        headers,
+        body: data as Uint8Array<ArrayBuffer>,
+        signal: options?.signal,
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Upload failed: ${response.status} ${await response.text().catch(() => "")}`);
+    }
+
+    const result = await response.json().catch(() => ({}));
+    return {
+      cid: result.etag ?? result.cid ?? "",
+      size: data.length,
+    };
+  }
+
+  async getObject(
+    bucketId: bigint,
+    key: string,
+  ): Promise<Uint8Array> {
+    const providerUrl = await this.getProviderUrl(bucketId);
+    const params = new URLSearchParams({ key });
+    const response = await httpFetch(
+      `${providerUrl}/s3/${Number(bucketId)}/object?${params.toString()}`,
+      { headers: this.signRequest("GET", bucketId) },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Download failed: ${response.status}`);
+    }
+
+    const buffer = await response.arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+
+  async listObjects(
+    bucketId: bigint,
+    prefix?: string,
+  ): Promise<S3ObjectInfo[]> {
+    const providerUrl = await this.getProviderUrl(bucketId);
+    const params = new URLSearchParams();
+    if (prefix) params.set("prefix", prefix);
+    const response = await httpFetch(
+      `${providerUrl}/s3/${Number(bucketId)}/objects?${params.toString()}`,
+      { headers: this.signRequest("GET", bucketId) },
+    );
+
+    if (!response.ok) {
+      throw new Error(`List objects failed: ${response.status}`);
+    }
+
+    const result = await response.json();
+    return (result.contents || []).map((o: any) => ({
+      key: o.key,
+      size: o.size ?? 0,
+      lastModified: (o.last_modified ?? o.lastModified ?? 0) * 1000,
+      etag: o.etag ?? "",
+    }));
+  }
+
+  async deleteObject(bucketId: bigint, key: string): Promise<void> {
+    const providerUrl = await this.getProviderUrl(bucketId);
+    const params = new URLSearchParams({ key });
+    const response = await httpFetch(
+      `${providerUrl}/s3/${Number(bucketId)}/object?${params.toString()}`,
+      {
+        method: "DELETE",
+        headers: this.signRequest("DELETE", bucketId),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Delete failed: ${response.status} ${await response.text().catch(() => "")}`);
+    }
+  }
+
+  // ── Members ─────────────────────────────────────────────────────────────
+
+  async getBucketMembers(bucketId: bigint): Promise<BucketMember[]> {
+    const api = this.requireApi();
+    const bucket = await api.query.StorageProvider.Buckets.getValue(bucketId);
+    if (!bucket) throw new Error(`Bucket ${bucketId} not found`);
+
+    const roleMap: Record<string, MemberRole> = {
+      Admin: "Admin",
+      Writer: "Writer",
+      Reader: "Reader",
+    };
+
+    return (bucket.members ?? []).map((m: { account: string; role: { type?: string } | string }) => {
+      const roleType = typeof m.role === "string" ? m.role : m.role?.type ?? "Reader";
+      return {
+        account: m.account,
+        role: roleMap[roleType] ?? "Reader",
+      };
+    });
+  }
+
+  async addMember(bucketId: bigint, account: string, role: MemberRole): Promise<void> {
+    const api = this.requireApi();
+    const tx = api.tx.StorageProvider.set_member({
+      bucket_id: bucketId,
+      member: account,
+      role: Enum(role),
+    });
+    await this.submit(tx);
+  }
+
+  async removeMember(bucketId: bigint, account: string): Promise<void> {
+    const api = this.requireApi();
+    const tx = api.tx.StorageProvider.remove_member({
+      bucket_id: bucketId,
+      member: account,
+    });
+    await this.submit(tx);
+  }
+
+  // ── Provider discovery ────────────────────────────────────────────────────
+
+  async listAvailableProviders(): Promise<AvailableProvider[]> {
+    const api = this.requireApi();
+    const entries = await api.query.StorageProvider.Providers.getEntries();
+    const providers: AvailableProvider[] = [];
+
+    for (const entry of entries) {
+      const provider = entry.value;
+      const account = entry.keyArgs[0] as string;
+      const settings = provider.settings;
+
+      const multiaddrStr = new TextDecoder().decode(provider.multiaddr);
+      const maxCapacity = BigInt(settings.max_capacity ?? 0);
+      const committedBytes = BigInt(provider.committed_bytes ?? 0);
+      const availableCapacity =
+        maxCapacity > committedBytes ? maxCapacity - committedBytes : 0n;
+
+      providers.push({
+        account,
+        multiaddr: multiaddrStr,
+        stake: BigInt(provider.stake ?? 0),
+        availableCapacity,
+        maxCapacity,
+        pricePerByte: BigInt(settings.price_per_byte ?? 0),
+        minDuration: settings.min_duration ?? 0,
+        maxDuration: settings.max_duration ?? 0,
+        acceptingPrimary: settings.accepting_primary ?? false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        agreementsTotal: (provider.stats as any)?.agreements_total ?? 0,
+      });
+    }
+
+    providers.sort((a, b) => {
+      if (b.availableCapacity > a.availableCapacity) return 1;
+      if (b.availableCapacity < a.availableCapacity) return -1;
+      return 0;
+    });
+
+    return providers;
+  }
+
+  async queryMatchingProviders(
+    query: QueryMatchingProvidersParams["query"],
+    limit: QueryMatchingProvidersParams["limit"],
+  ): Promise<MatchingProviders[]> {
+    const api = this.requireApi();
+    const matches = await api.apis.StorageProviderApi.find_matching_providers(
+      {
+        bytes_needed: query.bytesNeeded,
+        min_duration: query.minDuration,
+        max_price_per_byte: query.maxPricePerByte,
+        primary_only: query.primaryOnly,
+      },
+      limit,
+    );
+
+    return matches
+      .map((match) => {
+        const info = match.info;
+        const maxCapacity = BigInt(info.max_capacity ?? 0);
+        const committedBytes = BigInt(info.committed_bytes ?? 0);
+        const availableCapacity =
+          maxCapacity > committedBytes ? maxCapacity - committedBytes : 0n;
+
+        return {
+          account: toSs58(match.account),
+          multiaddr: new TextDecoder().decode(info.multiaddr),
+          stake: BigInt(info.stake ?? 0),
+          availableCapacity,
+          maxCapacity,
+          committedBytes,
+          pricePerByte: BigInt(info.price_per_byte ?? 0),
+          minDuration: info.min_duration ?? 0,
+          maxDuration: info.max_duration ?? 0,
+          acceptingPrimary: info.accepting_primary ?? false,
+          replicaSyncPrice:
+            info.replica_sync_price != null ? BigInt(info.replica_sync_price) : undefined,
+          acceptingExtensions: info.accepting_extensions ?? false,
+          registeredAt: Number(info.registered_at ?? 0),
+          agreementsTotal: info.agreements_total ?? 0,
+          agreementsExtended: info.agreements_extended ?? 0,
+          agreementsNotExtended: info.agreements_not_extended ?? 0,
+          agreementsBurned: info.agreements_burned ?? 0,
+          challengesReceived: info.challenges_received ?? 0,
+          challengesFailed: info.challenges_failed ?? 0,
+          matchScore: match.match_score,
+          partialReason: match.partial_reason?.type ?? "",
+        };
+      })
+      .sort((a, b) => b.matchScore - a.matchScore);
+  }
+
+  // ── Checkpoint ──────────────────────────────────────────────────────────
+
+  async getCheckpointInfo(bucketId: bigint): Promise<CheckpointInfo | null> {
+    const api = this.requireApi();
+    const bucket = await api.query.StorageProvider.Buckets.getValue(bucketId);
+    if (!bucket) throw new Error(`Bucket ${bucketId} not found`);
+
+    const snapshot = bucket.snapshot;
+    if (!snapshot) return null;
+
+    return {
+      mmrRoot: snapshot.mmr_root,
+      startSeq: snapshot.start_seq,
+      leafCount: snapshot.leaf_count,
+      checkpointBlock: snapshot.checkpoint_block,
+    };
+  }
+
+  async getCheckpointDuty(bucketId: bigint): Promise<CheckpointDuty | null> {
+    const providerUrl = await this.getProviderUrl(bucketId);
+    const response = await httpFetch(
+      `${providerUrl}/checkpoint/duty?bucket_id=${Number(bucketId)}`,
+    );
+
+    if (!response.ok) {
+      if (response.status === 404) return null;
+      throw new Error(`Checkpoint duty failed: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  async triggerCheckpoint(bucketId: bigint): Promise<void> {
+    const providerUrl = await this.getProviderUrl(bucketId);
+    const response = await httpFetch(
+      `${providerUrl}/checkpoint/trigger?bucket_id=${Number(bucketId)}`,
+      { method: "POST" },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Checkpoint trigger failed: ${response.status} ${await response.text().catch(() => "")}`);
+    }
+  }
+}
+
+export { parachain };

--- a/user-interfaces/s3-ui/src/lib/utils.ts
+++ b/user-interfaces/s3-ui/src/lib/utils.ts
@@ -1,0 +1,34 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function formatBytes(bytes: number | bigint): string {
+  const b = typeof bytes === "bigint" ? Number(bytes) : bytes;
+  if (b === 0) return "0 B";
+
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+  const i = Math.min(Math.floor(Math.log(b) / Math.log(k)), sizes.length - 1);
+
+  return `${parseFloat((b / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+export function truncateHash(hash: string, startChars = 6, endChars = 4): string {
+  if (hash.length <= startChars + endChars) return hash;
+  return `${hash.slice(0, startChars)}...${hash.slice(-endChars)}`;
+}
+
+export function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+export function formatTokens(units: bigint, decimals = 12): string {
+  const divisor = 10n ** BigInt(decimals);
+  const whole = units / divisor;
+  const frac = units % divisor;
+  const fracStr = frac.toString().padStart(decimals, "0").slice(0, 2);
+  return `${whole.toLocaleString()}.${fracStr}`;
+}

--- a/user-interfaces/s3-ui/src/main.tsx
+++ b/user-interfaces/s3-ui/src/main.tsx
@@ -1,0 +1,25 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { Subscribe } from "@react-rxjs/core";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import { connect } from "@/state/chain.state";
+import { getParachainWs } from "@/state/network.state";
+import { restoreSigner } from "@/state/wallet.state";
+import "./app.css";
+
+const basename = import.meta.env.BASE_URL.replace(/\/$/, "") || "/";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <Subscribe fallback={<div className="min-h-screen bg-background" />}>
+      <BrowserRouter basename={basename}>
+        <App />
+      </BrowserRouter>
+    </Subscribe>
+  </StrictMode>,
+);
+
+// Boot: connect to the parachain WS and restore any persisted signer.
+connect(getParachainWs());
+restoreSigner();

--- a/user-interfaces/s3-ui/src/state/chain.state.ts
+++ b/user-interfaces/s3-ui/src/state/chain.state.ts
@@ -1,0 +1,133 @@
+/**
+ * Chain State - Blockchain connection and block tracking.
+ *
+ * RxJS BehaviorSubjects + bind() hooks. Network-aware via network.state.ts.
+ * Patterned after user-interfaces/provider/src/state/chain.state.ts.
+ */
+
+import { BehaviorSubject, map, type Subscription } from "rxjs";
+import { bind } from "@react-rxjs/core";
+import { createClient, type PolkadotClient, type TypedApi } from "polkadot-api";
+import { getWsProvider } from "polkadot-api/ws";
+import { parachain } from "@polkadot-api/descriptors";
+import { setSs58Prefix } from "@web3-storage/papi";
+import { loadSelectedNetwork } from "@web3-storage/network-config";
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
+
+export type ParachainApi = TypedApi<typeof parachain>;
+
+const initialNetwork = loadSelectedNetwork();
+
+const connectionStatus$ = new BehaviorSubject<ConnectionStatus>("disconnected");
+const blockNumber$ = new BehaviorSubject<number>(0);
+const endpoint$ = new BehaviorSubject<string>(initialNetwork.config.parachainWs);
+const connectionError$ = new BehaviorSubject<string | undefined>(undefined);
+const client$ = new BehaviorSubject<PolkadotClient | null>(null);
+const api$ = new BehaviorSubject<ParachainApi | null>(null);
+
+let blockSubscription: Subscription | null = null;
+
+export const [useConnectionStatus] = bind(connectionStatus$, "disconnected");
+export const [useBlockNumber] = bind(blockNumber$, 0);
+export const [useEndpoint] = bind(endpoint$, initialNetwork.config.parachainWs);
+export const [useConnectionError] = bind(connectionError$, undefined);
+export const [useIsConnected] = bind(
+  connectionStatus$.pipe(map((s) => s === "connected")),
+  false,
+);
+export const [useIsConnecting] = bind(
+  connectionStatus$.pipe(map((s) => s === "connecting")),
+  false,
+);
+
+export async function connect(wsEndpoint?: string): Promise<void> {
+  const ep = wsEndpoint || endpoint$.getValue();
+
+  if (connectionStatus$.getValue() === "connected" && endpoint$.getValue() === ep) {
+    return;
+  }
+
+  if (client$.getValue()) {
+    disconnect();
+  }
+
+  endpoint$.next(ep);
+  connectionStatus$.next("connecting");
+  connectionError$.next(undefined);
+
+  try {
+    const provider = getWsProvider(ep);
+    const client = createClient(provider);
+    const api = client.getTypedApi(parachain);
+
+    blockSubscription = client.finalizedBlock$.subscribe((block) => {
+      blockNumber$.next(block.number);
+    });
+
+    client$.next(client);
+    api$.next(api);
+
+    // Render addresses with the runtime's SS58 prefix (per-network). Dev-account
+    // addresses are re-derived lazily on every setSigner(), so they pick this up.
+    try {
+      setSs58Prefix(await api.constants.System.SS58Prefix());
+    } catch {
+      /* keep the default prefix */
+    }
+
+    connectionStatus$.next("connected");
+  } catch (error) {
+    connectionStatus$.next("error");
+    connectionError$.next(
+      error instanceof Error ? error.message : "Connection failed",
+    );
+    throw error;
+  }
+}
+
+export function disconnect(): void {
+  if (blockSubscription) {
+    blockSubscription.unsubscribe();
+    blockSubscription = null;
+  }
+
+  const client = client$.getValue();
+  if (client) {
+    try {
+      client.destroy();
+    } catch {
+      /* already destroyed */
+    }
+  }
+
+  client$.next(null);
+  api$.next(null);
+  blockNumber$.next(0);
+  connectionStatus$.next("disconnected");
+}
+
+export async function reconnect(newEndpoint: string): Promise<void> {
+  disconnect();
+  await connect(newEndpoint);
+}
+
+export function getClient(): PolkadotClient | null {
+  return client$.getValue();
+}
+
+export function getApi(): ParachainApi | null {
+  return api$.getValue();
+}
+
+export function getEndpoint(): string {
+  return endpoint$.getValue();
+}
+
+export function isConnected(): boolean {
+  return connectionStatus$.getValue() === "connected";
+}
+
+export const client$$ = client$.asObservable();
+export const api$$ = api$.asObservable();
+export const endpointObs$ = endpoint$.asObservable();

--- a/user-interfaces/s3-ui/src/state/checkpoint.state.ts
+++ b/user-interfaces/s3-ui/src/state/checkpoint.state.ts
@@ -1,0 +1,51 @@
+/**
+ * Checkpoint State - read-only snapshot of bucket checkpoint info + provider
+ * duty status for the currently-selected bucket.
+ */
+
+import { BehaviorSubject } from "rxjs";
+import { bind } from "@react-rxjs/core";
+import type { CheckpointInfo, CheckpointDuty } from "@/lib/s3-client";
+import { getS3Client } from "@/state/s3.state";
+
+const checkpointInfo$ = new BehaviorSubject<CheckpointInfo | null>(null);
+const checkpointDuty$ = new BehaviorSubject<CheckpointDuty | null>(null);
+const checkpointLoading$ = new BehaviorSubject<boolean>(false);
+
+export const [useCheckpointInfo] = bind(checkpointInfo$, null);
+export const [useCheckpointDuty] = bind(checkpointDuty$, null);
+export const [useCheckpointLoading] = bind(checkpointLoading$, false);
+
+export async function refreshCheckpoint(bucketId: bigint | null): Promise<void> {
+  if (bucketId === null) {
+    checkpointInfo$.next(null);
+    checkpointDuty$.next(null);
+    return;
+  }
+  const client = getS3Client();
+  if (!client.hasApi()) return;
+  checkpointLoading$.next(true);
+  try {
+    const [info, duty] = await Promise.all([
+      client.getCheckpointInfo(bucketId).catch(() => null),
+      client.getCheckpointDuty(bucketId).catch(() => null),
+    ]);
+    checkpointInfo$.next(info);
+    checkpointDuty$.next(duty);
+  } finally {
+    checkpointLoading$.next(false);
+  }
+}
+
+export async function triggerCheckpoint(bucketId: bigint): Promise<void> {
+  const client = getS3Client();
+  await client.triggerCheckpoint(bucketId);
+  setTimeout(() => {
+    refreshCheckpoint(bucketId).catch(() => {});
+  }, 5000);
+}
+
+export function clearCheckpointState(): void {
+  checkpointInfo$.next(null);
+  checkpointDuty$.next(null);
+}

--- a/user-interfaces/s3-ui/src/state/index.ts
+++ b/user-interfaces/s3-ui/src/state/index.ts
@@ -1,0 +1,100 @@
+// Chain
+export {
+  useConnectionStatus,
+  useIsConnected,
+  useIsConnecting,
+  useBlockNumber,
+  useEndpoint,
+  useConnectionError,
+  connect,
+  disconnect,
+  reconnect,
+  getClient,
+  getApi,
+  getEndpoint,
+  isConnected,
+  type ParachainApi,
+} from "./chain.state";
+
+// Network
+export {
+  useSelectedNetworkId,
+  useSelectedNetwork,
+  useParachainWs,
+  useProviderHttp,
+  useNetworkList,
+  selectNetwork,
+  selectCustomNetwork,
+  getSelectedNetwork,
+  getParachainWs,
+  getProviderHttp,
+} from "./network.state";
+
+export type { NetworkId, NetworkConfig } from "@web3-storage/network-config";
+
+// Wallet
+export {
+  useSignerAddress,
+  useSignerName,
+  useBalance,
+  useIsSettingSigner,
+  useHasSigner,
+  setSigner,
+  selectDevAccount,
+  clearSigner,
+  refreshBalance,
+  restoreSigner,
+  getSignerAddress,
+  DEV_ACCOUNTS,
+} from "./wallet.state";
+
+// S3
+export {
+  useBuckets,
+  useSelectedBucket,
+  useCurrentPrefix,
+  useObjects,
+  useS3Loading,
+  useUploading,
+  useS3Error,
+  useViewMode,
+  useCreations,
+  useEncryptionKey,
+  refreshBuckets,
+  selectBucket,
+  navigateToPrefix,
+  navigateUp,
+  refreshObjects,
+  setViewMode,
+  uploadFiles,
+  uploadObject,
+  abortUpload,
+  downloadObject,
+  deleteObject,
+  createBucket,
+  retryCreation,
+  canRetryCreation,
+  dismissCreation,
+  deleteBucket,
+  listAvailableProviders,
+  queryMatchingProviders,
+  fetchMembers,
+  addMember,
+  removeMember,
+  setEncryptionKey,
+  clearEncryptionKey,
+  getS3Client,
+  type CreationStatus,
+  type CreateBucketInput,
+  type ViewMode,
+} from "./s3.state";
+
+// Checkpoint
+export {
+  useCheckpointInfo,
+  useCheckpointDuty,
+  useCheckpointLoading,
+  refreshCheckpoint,
+  triggerCheckpoint,
+  clearCheckpointState,
+} from "./checkpoint.state";

--- a/user-interfaces/s3-ui/src/state/network.state.ts
+++ b/user-interfaces/s3-ui/src/state/network.state.ts
@@ -1,0 +1,78 @@
+/**
+ * Network State - Network selection and persistence.
+ *
+ * Wraps @web3-storage/network-config with RxJS subjects + bind() hooks.
+ */
+
+import { BehaviorSubject, map } from "rxjs";
+import { bind } from "@react-rxjs/core";
+import {
+  type NetworkId,
+  type NetworkConfig,
+  NETWORKS,
+  NETWORK_LIST,
+  loadSelectedNetwork,
+  saveSelectedNetwork,
+  createCustomNetwork,
+} from "@web3-storage/network-config";
+import { reconnect, getEndpoint } from "@/state/chain.state";
+
+const persisted = loadSelectedNetwork();
+
+const selectedNetworkId$ = new BehaviorSubject<NetworkId>(persisted.id);
+const selectedNetwork$ = new BehaviorSubject<NetworkConfig>(persisted.config);
+
+export const [useSelectedNetworkId] = bind(selectedNetworkId$, persisted.id);
+export const [useSelectedNetwork] = bind(selectedNetwork$, persisted.config);
+export const [useParachainWs] = bind(
+  selectedNetwork$.pipe(map((n) => n.parachainWs)),
+  persisted.config.parachainWs,
+);
+export const [useProviderHttp] = bind(
+  selectedNetwork$.pipe(map((n) => n.providerHttp)),
+  persisted.config.providerHttp,
+);
+export const [useNetworkList] = bind(
+  new BehaviorSubject(NETWORK_LIST),
+  NETWORK_LIST,
+);
+
+export async function selectNetwork(id: NetworkId): Promise<void> {
+  const config = NETWORKS[id];
+  if (!config) return;
+
+  selectedNetworkId$.next(id);
+  selectedNetwork$.next(config);
+  saveSelectedNetwork(id);
+
+  if (config.parachainWs && config.parachainWs !== getEndpoint()) {
+    await reconnect(config.parachainWs);
+  }
+}
+
+export async function selectCustomNetwork(input: {
+  parachainWs: string;
+  providerHttp: string;
+}): Promise<void> {
+  const config = createCustomNetwork(input.parachainWs, input.providerHttp);
+
+  selectedNetworkId$.next("custom");
+  selectedNetwork$.next(config);
+  saveSelectedNetwork("custom", config);
+
+  if (config.parachainWs) {
+    await reconnect(config.parachainWs);
+  }
+}
+
+export function getSelectedNetwork(): NetworkConfig {
+  return selectedNetwork$.getValue();
+}
+
+export function getParachainWs(): string {
+  return selectedNetwork$.getValue().parachainWs;
+}
+
+export function getProviderHttp(): string {
+  return selectedNetwork$.getValue().providerHttp;
+}

--- a/user-interfaces/s3-ui/src/state/s3.state.ts
+++ b/user-interfaces/s3-ui/src/state/s3.state.ts
@@ -1,0 +1,537 @@
+/**
+ * S3 State — bucket/object orchestration over an S3Client.
+ *
+ * Owns the S3Client instance, syncing it with chain.state.ts (api) and
+ * wallet.state.ts (signer). Holds buckets/objects/selection state. Subscribes
+ * to S3Registry events for real-time updates.
+ */
+
+import { BehaviorSubject, combineLatest, distinctUntilChanged, Subscription } from "rxjs";
+import { bind } from "@react-rxjs/core";
+import {
+  S3Client,
+  type AvailableProvider,
+  type BucketInfo,
+  type MatchingProviders,
+  type QueryMatchingProvidersParams,
+  type S3ObjectInfo,
+  type SignedTerms,
+} from "@/lib/s3-client";
+import { EncryptionKey, hexToBytes } from "@/lib/encryption";
+import { api$$, getApi } from "@/state/chain.state";
+import { signer$$, keypair$$, signerAddress$$, getSignerAddress, refreshBalance } from "@/state/wallet.state";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CreationStage = "submitting" | "ready" | "failed";
+
+export interface CreationStatus {
+  id: string;
+  name: string;
+  stage: CreationStage;
+  elapsedMs: number;
+  error?: string;
+  s3BucketId?: bigint;
+}
+
+export interface CreateBucketInput {
+  name: string;
+  provider: AvailableProvider;
+  url: string;
+  signed: SignedTerms;
+}
+
+export type ViewMode = "list" | "grid";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// localStorage hydration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STORAGE_VIEW_MODE = "s3-ui-view-mode";
+const STORAGE_SELECTED_BUCKET = "s3-ui-selected-bucket";
+const STORAGE_CURRENT_PREFIX = "s3-ui-current-prefix";
+
+function readViewMode(): ViewMode {
+  const v = localStorage.getItem(STORAGE_VIEW_MODE);
+  return v === "grid" ? "grid" : "list";
+}
+
+function readSelectedBucketId(): bigint | null {
+  const v = localStorage.getItem(STORAGE_SELECTED_BUCKET);
+  if (!v) return null;
+  try {
+    return BigInt(v);
+  } catch {
+    return null;
+  }
+}
+
+function readCurrentPrefix(): string {
+  return localStorage.getItem(STORAGE_CURRENT_PREFIX) || "";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client lifecycle (one S3Client per session, kept in sync with api/signer)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const client = new S3Client();
+
+api$$.subscribe((api) => {
+  client.setApi(api);
+});
+
+combineLatest([signer$$, signerAddress$$]).subscribe(([signer, address]) => {
+  client.setSigner(signer, address);
+});
+
+keypair$$.subscribe((keypair) => {
+  client.setKeypair(keypair);
+});
+
+export function getS3Client(): S3Client {
+  return client;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State subjects
+// ─────────────────────────────────────────────────────────────────────────────
+
+const buckets$ = new BehaviorSubject<BucketInfo[]>([]);
+const selectedBucket$ = new BehaviorSubject<BucketInfo | null>(null);
+const currentPrefix$ = new BehaviorSubject<string>(readCurrentPrefix());
+const objects$ = new BehaviorSubject<S3ObjectInfo[]>([]);
+const loading$ = new BehaviorSubject<boolean>(false);
+const uploading$ = new BehaviorSubject<{ active: boolean; progress: number }>({
+  active: false,
+  progress: 0,
+});
+const error$ = new BehaviorSubject<string | null>(null);
+const viewMode$ = new BehaviorSubject<ViewMode>(readViewMode());
+const creations$ = new BehaviorSubject<CreationStatus[]>([]);
+const encryptionKey$ = new BehaviorSubject<EncryptionKey | null>(null);
+
+let uploadAbortController: AbortController | null = null;
+let pendingSelectedBucketId: bigint | null = readSelectedBucketId();
+
+// Persist viewMode + currentPrefix + selected bucket id
+viewMode$.subscribe((mode) => localStorage.setItem(STORAGE_VIEW_MODE, mode));
+currentPrefix$.subscribe((prefix) => localStorage.setItem(STORAGE_CURRENT_PREFIX, prefix));
+selectedBucket$.subscribe((b) => {
+  if (b) localStorage.setItem(STORAGE_SELECTED_BUCKET, b.s3BucketId.toString());
+  else localStorage.removeItem(STORAGE_SELECTED_BUCKET);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hooks
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const [useBuckets] = bind(buckets$, []);
+export const [useSelectedBucket] = bind(selectedBucket$, null);
+export const [useCurrentPrefix] = bind(currentPrefix$, "");
+export const [useObjects] = bind(objects$, []);
+export const [useS3Loading] = bind(loading$, false);
+export const [useUploading] = bind(uploading$, { active: false, progress: 0 });
+export const [useS3Error] = bind(error$, null);
+export const [useViewMode] = bind(viewMode$, "list");
+export const [useCreations] = bind(creations$, []);
+export const [useEncryptionKey] = bind(encryptionKey$, null);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bucket CRUD
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function refreshBuckets(): Promise<void> {
+  if (!client.hasApi() || !client.hasSigner()) return;
+  loading$.next(true);
+  try {
+    const list = await client.listBuckets();
+    buckets$.next(list);
+
+    const sel = selectedBucket$.getValue();
+    if (sel) {
+      const updated = list.find((b) => b.s3BucketId === sel.s3BucketId) ?? null;
+      if (updated && updated.name !== sel.name) {
+        selectedBucket$.next(updated);
+      } else if (!updated) {
+        selectedBucket$.next(null);
+        objects$.next([]);
+      }
+    } else if (pendingSelectedBucketId !== null) {
+      const persisted = list.find((b) => b.s3BucketId === pendingSelectedBucketId);
+      if (persisted) {
+        selectedBucket$.next(persisted);
+      }
+      pendingSelectedBucketId = null;
+    }
+
+    error$.next(null);
+  } catch (err) {
+    error$.next(err instanceof Error ? err.message : "Failed to load buckets");
+  } finally {
+    loading$.next(false);
+  }
+}
+
+export async function selectBucket(bucket: BucketInfo | null): Promise<void> {
+  selectedBucket$.next(bucket);
+  if (!bucket) {
+    objects$.next([]);
+    currentPrefix$.next("");
+    return;
+  }
+  currentPrefix$.next("");
+}
+
+export function navigateToPrefix(prefix: string): void {
+  currentPrefix$.next(prefix);
+}
+
+export function navigateUp(): void {
+  const prefix = currentPrefix$.getValue();
+  if (!prefix) return;
+  const parts = prefix.split("/").filter(Boolean);
+  parts.pop();
+  currentPrefix$.next(parts.length === 0 ? "" : parts.join("/") + "/");
+}
+
+export async function refreshObjects(): Promise<void> {
+  const bucket = selectedBucket$.getValue();
+  if (!bucket || !client.hasApi()) return;
+  loading$.next(true);
+  error$.next(null);
+  try {
+    const list = await client.listObjects(bucket.layer0BucketId, currentPrefix$.getValue() || undefined);
+    objects$.next(list);
+  } catch (err) {
+    error$.next(err instanceof Error ? err.message : "Failed to list objects");
+    objects$.next([]);
+  } finally {
+    loading$.next(false);
+  }
+}
+
+export function setViewMode(mode: ViewMode): void {
+  viewMode$.next(mode);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Object operations
+// ─────────────────────────────────────────────────────────────────────────────
+
+function readFileAsUint8Array(file: File): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) resolve(new Uint8Array(reader.result));
+      else reject(new Error("Failed to read file"));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+export async function uploadFiles(files: File[]): Promise<void> {
+  const bucket = selectedBucket$.getValue();
+  if (!bucket || !client.hasApi()) return;
+  if (files.length === 0) return;
+
+  uploadAbortController = new AbortController();
+  const signal = uploadAbortController.signal;
+  uploading$.next({ active: true, progress: 0 });
+
+  const uploaded: string[] = [];
+  let aborted = false;
+
+  try {
+    const prefix = currentPrefix$.getValue();
+    for (let i = 0; i < files.length; i++) {
+      if (signal.aborted) {
+        aborted = true;
+        break;
+      }
+      const file = files[i]!;
+      let data = await readFileAsUint8Array(file);
+
+      // Encrypt if encryption key is set
+      const key = encryptionKey$.getValue();
+      if (key) {
+        data = await key.encrypt(data);
+      }
+
+      const objectKey = prefix ? `${prefix}${file.name}` : file.name;
+      await client.putObject(bucket.layer0BucketId, objectKey, data, { signal });
+      uploaded.push(file.name);
+      uploading$.next({ active: true, progress: ((i + 1) / files.length) * 100 });
+    }
+  } finally {
+    uploading$.next({ active: false, progress: 0 });
+    uploadAbortController = null;
+    if (uploaded.length > 0) {
+      await refreshObjects();
+    }
+  }
+
+  if (aborted && uploaded.length < files.length) {
+    throw new DOMException("Upload aborted", "AbortError");
+  }
+}
+
+export async function uploadObject(key: string, file: File): Promise<void> {
+  const bucket = selectedBucket$.getValue();
+  if (!bucket || !client.hasApi()) return;
+
+  uploading$.next({ active: true, progress: 0 });
+  try {
+    let data = await readFileAsUint8Array(file);
+
+    const eKey = encryptionKey$.getValue();
+    if (eKey) {
+      data = await eKey.encrypt(data);
+    }
+
+    await client.putObject(bucket.layer0BucketId, key, data);
+    uploading$.next({ active: true, progress: 100 });
+    await refreshObjects();
+  } finally {
+    uploading$.next({ active: false, progress: 0 });
+  }
+}
+
+export function abortUpload(): void {
+  uploadAbortController?.abort();
+}
+
+export async function downloadObject(key: string): Promise<Uint8Array> {
+  const bucket = selectedBucket$.getValue();
+  if (!bucket) throw new Error("No bucket selected");
+  let data = await client.getObject(bucket.layer0BucketId, key);
+
+  // Decrypt if encryption key is set and data looks encrypted (version byte 0x02)
+  const eKey = encryptionKey$.getValue();
+  if (eKey && data.length > 0 && data[0] === 0x02) {
+    data = await eKey.decrypt(data);
+  }
+
+  return data;
+}
+
+export async function deleteObject(key: string): Promise<void> {
+  const bucket = selectedBucket$.getValue();
+  if (!bucket) return;
+  await client.deleteObject(bucket.layer0BucketId, key);
+  await refreshObjects();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Encryption
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function setEncryptionKey(hexKey: string): Promise<void> {
+  const rawKey = hexToBytes(hexKey);
+  encryptionKey$.next(await EncryptionKey.fromBytes(rawKey));
+}
+
+export function clearEncryptionKey(): void {
+  encryptionKey$.next(null);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bucket lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+function updateCreation(id: string, updates: Partial<CreationStatus>): void {
+  creations$.next(creations$.getValue().map((c) => (c.id === id ? { ...c, ...updates } : c)));
+}
+
+export function dismissCreation(id: string): void {
+  creations$.next(creations$.getValue().filter((c) => c.id !== id));
+}
+
+interface RetryCtx {
+  name: string;
+  provider: AvailableProvider;
+  url: string;
+  signed: SignedTerms;
+}
+const retryCtx = new Map<string, RetryCtx>();
+
+export function canRetryCreation(id: string): boolean {
+  return retryCtx.has(id);
+}
+
+async function runChainSubmit(id: string, ctx: RetryCtx): Promise<BucketInfo | null> {
+  updateCreation(id, { stage: "submitting", error: undefined });
+  try {
+    const bucket = await client.createBucket(ctx.name, ctx.provider.account, ctx.url, ctx.signed);
+    updateCreation(id, { stage: "ready", s3BucketId: bucket.s3BucketId });
+    retryCtx.delete(id);
+    await refreshBuckets();
+    const refreshed = buckets$.getValue().find((b) => b.s3BucketId === bucket.s3BucketId) ?? bucket;
+    await selectBucket(refreshed);
+    await refreshBalance();
+    return refreshed;
+  } catch (err) {
+    updateCreation(id, {
+      stage: "failed",
+      error: err instanceof Error ? err.message : "Failed to submit on chain",
+    });
+    return null;
+  }
+}
+
+export async function createBucket(input: CreateBucketInput): Promise<BucketInfo | null> {
+  if (!client.hasApi() || !client.hasSigner()) return null;
+
+  const id = crypto.randomUUID();
+  creations$.next([
+    ...creations$.getValue(),
+    { id, name: input.name, stage: "submitting", elapsedMs: 0 },
+  ]);
+
+  const ctx: RetryCtx = {
+    name: input.name,
+    provider: input.provider,
+    url: input.url,
+    signed: input.signed,
+  };
+  retryCtx.set(id, ctx);
+  return runChainSubmit(id, ctx);
+}
+
+export async function retryCreation(id: string): Promise<BucketInfo | null> {
+  const ctx = retryCtx.get(id);
+  if (!ctx) return null;
+  return runChainSubmit(id, ctx);
+}
+
+export async function listAvailableProviders(): Promise<AvailableProvider[]> {
+  if (!client.hasApi()) return [];
+  return client.listAvailableProviders();
+}
+
+const DEFAULT_PROVIDER_LIMIT = 10;
+export async function queryMatchingProviders(
+  query: QueryMatchingProvidersParams["query"],
+  limit: QueryMatchingProvidersParams["limit"] = DEFAULT_PROVIDER_LIMIT,
+): Promise<MatchingProviders[]> {
+  if (!client.hasApi()) return [];
+  return client.queryMatchingProviders(query, limit);
+}
+
+export async function deleteBucket(s3BucketId: bigint): Promise<void> {
+  if (!client.hasApi() || !client.hasSigner()) return;
+  await client.deleteBucket(s3BucketId);
+  if (selectedBucket$.getValue()?.s3BucketId === s3BucketId) {
+    selectedBucket$.next(null);
+    objects$.next([]);
+    currentPrefix$.next("");
+  }
+  await refreshBuckets();
+  await refreshBalance();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Members
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function fetchMembers(bucketId: bigint) {
+  if (!client.hasApi()) return [];
+  return client.getBucketMembers(bucketId);
+}
+
+export async function addMember(
+  bucketId: bigint,
+  account: string,
+  role: import("@/lib/s3-client").MemberRole,
+): Promise<void> {
+  await client.addMember(bucketId, account, role);
+}
+
+export async function removeMember(bucketId: bigint, account: string): Promise<void> {
+  await client.removeMember(bucketId, account);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Real-time S3Registry event subscription
+// ─────────────────────────────────────────────────────────────────────────────
+
+let eventSub: Subscription | null = null;
+
+function subscribeToS3Events(): void {
+  eventSub?.unsubscribe();
+  eventSub = null;
+  const api = getApi();
+  if (!api) return;
+
+  const handle = (s3BucketId: bigint, owner: string): void => {
+    const ownAddr = getSignerAddress();
+    const tracked = new Set(buckets$.getValue().map((b) => b.s3BucketId));
+    if (owner !== ownAddr && !tracked.has(s3BucketId)) return;
+    queueMicrotask(() => refreshBuckets().catch(() => {}));
+  };
+
+  eventSub = new Subscription();
+  eventSub.add(
+    api.event.S3Registry.S3BucketCreated.watch().subscribe({
+      next: ({ events }) => events.forEach((ev) => handle(ev.payload.s3_bucket_id, ev.payload.owner)),
+      error: () => {},
+    }),
+  );
+  eventSub.add(
+    api.event.S3Registry.S3BucketDeleted.watch().subscribe({
+      next: ({ events }) => events.forEach((ev) => handle(ev.payload.s3_bucket_id, "")),
+      error: () => {},
+    }),
+  );
+}
+
+api$$.subscribe(() => {
+  subscribeToS3Events();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reactive: refresh buckets when api+signer become available; refresh objects
+// when (selectedBucket, currentPrefix) change.
+// ─────────────────────────────────────────────────────────────────────────────
+
+combineLatest([api$$, signerAddress$$])
+  .pipe(distinctUntilChanged((a, b) => a[0] === b[0] && a[1] === b[1]))
+  .subscribe(([api, address]) => {
+    if (api && address) {
+      buckets$.next([]);
+      selectedBucket$.next(null);
+      objects$.next([]);
+      currentPrefix$.next("");
+      refreshBuckets().catch(() => {});
+    } else {
+      buckets$.next([]);
+      selectedBucket$.next(null);
+      objects$.next([]);
+    }
+  });
+
+combineLatest([selectedBucket$, currentPrefix$])
+  .pipe(distinctUntilChanged((a, b) => a[0]?.s3BucketId === b[0]?.s3BucketId && a[1] === b[1]))
+  .subscribe(([bucket]) => {
+    if (bucket && client.hasApi()) {
+      refreshObjects().catch(() => {});
+    }
+  });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Non-reactive getters
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function getBuckets(): BucketInfo[] {
+  return buckets$.getValue();
+}
+
+export function getSelectedBucket(): BucketInfo | null {
+  return selectedBucket$.getValue();
+}
+
+export function getCurrentPrefix(): string {
+  return currentPrefix$.getValue();
+}

--- a/user-interfaces/s3-ui/src/state/wallet.state.ts
+++ b/user-interfaces/s3-ui/src/state/wallet.state.ts
@@ -1,0 +1,146 @@
+/**
+ * Wallet State - Signer (account) selection.
+ *
+ * Drive-ui keeps the existing dev-account-by-seed model (Alice/Bob/Charlie/Dave
+ * + custom seed input) since browser-extension flows aren't required for the
+ * common case. Account NAME is persisted to localStorage so the user comes back
+ * to the same identity on reload (the seed is re-derived on hydration for the
+ * known dev paths; custom seeds are not auto-restored).
+ */
+
+import { BehaviorSubject, combineLatest, map } from "rxjs";
+import { bind } from "@react-rxjs/core";
+import { getPolkadotSigner } from "polkadot-api/signer";
+import { getApi } from "@/state/chain.state";
+import { seedToKeypair, toSs58 } from "@/lib/crypto";
+
+export type Signer = ReturnType<typeof getPolkadotSigner>;
+
+export interface DevAccount {
+  name: string;
+  seed: string;
+  color: string;
+}
+
+export const DEV_ACCOUNTS: DevAccount[] = [
+  { name: "Alice", seed: "//Alice", color: "bg-indigo-100 text-indigo-700 border-indigo-200" },
+  { name: "Bob", seed: "//Bob", color: "bg-emerald-100 text-emerald-700 border-emerald-200" },
+  { name: "Charlie", seed: "//Charlie", color: "bg-amber-100 text-amber-700 border-amber-200" },
+  { name: "Dave", seed: "//Dave", color: "bg-rose-100 text-rose-700 border-rose-200" },
+];
+
+export interface AccountBalance {
+  free: bigint;
+  reserved: bigint;
+}
+
+const STORAGE_KEY_ACCOUNT_NAME = "drive-ui-account-name";
+
+const signer$ = new BehaviorSubject<Signer | null>(null);
+const keypair$ = new BehaviorSubject<import("@/lib/crypto").Keypair | null>(null);
+const signerAddress$ = new BehaviorSubject<string | null>(null);
+const signerName$ = new BehaviorSubject<string | null>(null);
+const balance$ = new BehaviorSubject<AccountBalance | null>(null);
+const settingSigner$ = new BehaviorSubject<boolean>(false);
+
+export const [useSignerAddress] = bind(signerAddress$, null);
+export const [useSignerName] = bind(signerName$, null);
+export const [useBalance] = bind(balance$, null);
+export const [useIsSettingSigner] = bind(settingSigner$, false);
+
+export const [useHasSigner] = bind(
+  signerAddress$.pipe(map((a) => a !== null)),
+  false,
+);
+
+export async function setSigner(seed: string, name?: string): Promise<string> {
+  settingSigner$.next(true);
+  try {
+    const keypair = seedToKeypair(seed);
+    const address = toSs58(keypair.publicKey);
+
+    const newSigner = getPolkadotSigner(keypair.publicKey, "Sr25519", (input) =>
+      keypair.sign(input),
+    );
+
+    signer$.next(newSigner);
+    keypair$.next(keypair);
+    signerAddress$.next(address);
+    signerName$.next(name ?? null);
+
+    if (name) {
+      localStorage.setItem(STORAGE_KEY_ACCOUNT_NAME, name);
+    } else {
+      localStorage.removeItem(STORAGE_KEY_ACCOUNT_NAME);
+    }
+
+    await refreshBalance();
+    return address;
+  } finally {
+    settingSigner$.next(false);
+  }
+}
+
+export async function selectDevAccount(name: string): Promise<void> {
+  const dev = DEV_ACCOUNTS.find((a) => a.name === name);
+  if (!dev) throw new Error(`Unknown dev account: ${name}`);
+  await setSigner(dev.seed, dev.name);
+}
+
+export function clearSigner(): void {
+  signer$.next(null);
+  keypair$.next(null);
+  signerAddress$.next(null);
+  signerName$.next(null);
+  balance$.next(null);
+  localStorage.removeItem(STORAGE_KEY_ACCOUNT_NAME);
+}
+
+export async function refreshBalance(): Promise<void> {
+  const api = getApi();
+  const address = signerAddress$.getValue();
+  if (!api || !address) return;
+
+  try {
+    const account = await api.query.System.Account.getValue(address);
+    balance$.next({ free: account.data.free, reserved: account.data.reserved });
+  } catch {
+    /* leave previous balance in place on transient failure */
+  }
+}
+
+/**
+ * Restore signer from persisted account name. Only restores known dev accounts;
+ * custom seeds are intentionally not persisted.
+ */
+export async function restoreSigner(): Promise<void> {
+  const savedName = localStorage.getItem(STORAGE_KEY_ACCOUNT_NAME);
+  if (!savedName) return;
+  const dev = DEV_ACCOUNTS.find((a) => a.name === savedName);
+  if (!dev) return;
+  try {
+    await setSigner(dev.seed, dev.name);
+  } catch {
+    localStorage.removeItem(STORAGE_KEY_ACCOUNT_NAME);
+  }
+}
+
+export function getSigner(): Signer | null {
+  return signer$.getValue();
+}
+
+export function getKeypair(): import("@/lib/crypto").Keypair | null {
+  return keypair$.getValue();
+}
+
+export function getSignerAddress(): string | null {
+  return signerAddress$.getValue();
+}
+
+export const signer$$ = signer$.asObservable();
+export const keypair$$ = keypair$.asObservable();
+export const signerAddress$$ = signerAddress$.asObservable();
+
+export const signerInfo$ = combineLatest([signerAddress$, signerName$]).pipe(
+  map(([address, name]) => ({ address, name })),
+);

--- a/user-interfaces/s3-ui/src/vite-env.d.ts
+++ b/user-interfaces/s3-ui/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/user-interfaces/s3-ui/tsconfig.app.json
+++ b/user-interfaces/s3-ui/tsconfig.app.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/user-interfaces/s3-ui/tsconfig.json
+++ b/user-interfaces/s3-ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/user-interfaces/s3-ui/tsconfig.node.json
+++ b/user-interfaces/s3-ui/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/user-interfaces/s3-ui/vite.config.ts
+++ b/user-interfaces/s3-ui/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { resolve } from "path";
+
+const ghBase = process.env.VITE_BASE_PATH || "/";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  base: ghBase,
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 5177,
+  },
+});


### PR DESCRIPTION
## Summary
- Bootstrap `s3-ui` package with Vite + React + TypeScript configuration
- S3-compatible client library (`lib/s3-client.ts`): putObject, getObject, listObjects, bucket lifecycle
- RxJS-based state management: chain, network, wallet, S3, checkpoint
- Client-side encryption helpers (`lib/encryption.ts`, `lib/crypto.ts`)
- Shared shadcn/ui primitives: button, card, dialog, input, progress, toaster, menus
- App boots but renders a placeholder — components follow in subsequent PRs

**Stack**: 1/6 → [#2 Shell + buckets] → [#3 Object browser] → [#4 Encryption + checkpoints] → [#5 Landing integration] → [#6 Remove console-ui]

## Test plan
- [ ] `pnpm install` and `pnpm --filter @web3-storage/s3-ui build` pass
- [ ] App starts on port 5177 and renders placeholder

Part of #187