### PR TITLE
Fix challenge history crash from stale localStorage

### DIFF
--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -138,7 +138,22 @@ const CHALLENGES_GENESIS_KEY = 'provider-challenges-genesis'
 function loadPersistedChallenges(): Challenge[] {
   try {
     const raw = localStorage.getItem(CHALLENGES_STORAGE_KEY)
-    return raw ? JSON.parse(raw) : []
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as Partial<Challenge>[]
+    return parsed.map((c) => ({
+      id: c.id ?? 0,
+      bucketId: c.bucketId ?? 0,
+      challenger: c.challenger ?? '',
+      provider: c.provider ?? '',
+      leafIndex: c.leafIndex ?? 0,
+      chunkIndex: c.chunkIndex ?? 0,
+      mmrRoot: c.mmrRoot ?? '',
+      startSeq: c.startSeq ?? 0,
+      status: c.status ?? 'expired',
+      challengeType: c.challengeType,
+      createdAt: c.createdAt ?? 0,
+      deadline: c.deadline ?? 0,
+    }))
   } catch { return [] }
 }
 function persistChallenges(challenges: Challenge[]) {


### PR DESCRIPTION
## Summary

- Challenges persisted in localStorage before `provider-ui/manual-challenge-response` lack `chunkIndex`, `mmrRoot`, and `startSeq` fields
- The Challenges table calls `.toLocaleString()` on these undefined fields, which throws and silently crashes the entire page
- Fix: default all fields when deserializing from localStorage so old cached data is safe

## Test plan

- [ ] Clear localStorage, load Challenges page — no crash, empty state shown
- [ ] With old-format challenge data in localStorage (missing `chunkIndex`) — page renders with defaults
- [ ] New challenges populate all fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)