### PR TITLE
Fix challenge history crash from stale localStorage

### DIFF
--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -135,7 +135,19 @@ const CHALLENGES_GENESIS_KEY = 'provider-challenges-genesis'
 function loadPersistedChallenges(): Challenge[] {
   try {
     const raw = localStorage.getItem(CHALLENGES_STORAGE_KEY)
-    return raw ? JSON.parse(raw) : []
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as Partial<Challenge>[]
+    return parsed.map((c) => ({
+      id: c.id ?? 0,
+      bucketId: c.bucketId ?? 0,
+      challenger: c.challenger ?? '',
+      provider: c.provider ?? '',
+      leafIndex: c.leafIndex ?? 0,
+      status: c.status ?? 'expired',
+      challengeType: c.challengeType,
+      createdAt: c.createdAt ?? 0,
+      deadline: c.deadline ?? 0,
+    }))
   } catch { return [] }
 }
 function persistChallenges(challenges: Challenge[]) {


### PR DESCRIPTION
## Summary

- Challenges loaded from localStorage may have missing fields if the schema changed between versions
- Accessing undefined fields (e.g. `.toLocaleString()` on `undefined`) in the table renderer crashes the Challenges page silently
- Default all fields when deserializing from localStorage so cached data from older versions is safe

## Test plan

- [ ] Clear localStorage, load Challenges page — no crash, empty state shown
- [ ] With old-format challenge data in localStorage — page renders with defaults
- [ ] New challenges populate all fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)