### PR TITLE
Skip CI for docs-only changes

### DIFF
--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -48,6 +48,7 @@ jobs:
           filters: |
             runtime:
               - 'runtime/**'
+              - 'runtimes/**'
               - 'pallet/**'
               - 'primitives/**'
               - 'storage-interfaces/**/pallet-*/**'

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -48,6 +48,7 @@ jobs:
           filters: |
             runtime:
               - 'runtime/**'
+              - 'runtimes/**'
               - 'pallet/**'
               - 'primitives/**'
               - 'storage-interfaces/**/pallet-*/**'
@@ -57,6 +58,8 @@ jobs:
 
   runtime-matrix:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.runtime == 'true'
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -29,6 +29,32 @@ jobs:
       contents: read
     uses: ./.github/workflows/set-image.yml
 
+  # Skip migration checks when only docs/non-runtime files changed.
+  # Always runs on schedule (snapshot refresh) and workflow_dispatch.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      runtime: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || steps.filter.outputs.runtime == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+        id: filter
+        with:
+          filters: |
+            runtime:
+              - 'runtime/**'
+              - 'pallet/**'
+              - 'primitives/**'
+              - 'storage-interfaces/**/pallet-*/**'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/check-runtime-migration.yml'
+
   runtime-matrix:
     runs-on: ubuntu-latest
     permissions:
@@ -159,10 +185,10 @@ jobs:
 
   check-migrations:
     name: check-migration (${{ matrix.runtime.name }})
-    needs: [set-image, runtime-matrix, prepare-snapshots]
+    needs: [set-image, runtime-matrix, prepare-snapshots, changes]
     runs-on: parity-large
     timeout-minutes: 120
-    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.runtime == 'true'
     permissions:
       contents: read
     container:
@@ -239,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     name: All migrations passed
     if: always() && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    needs: [runtime-matrix, prepare-snapshots, check-migrations]
+    needs: [changes, runtime-matrix, prepare-snapshots, check-migrations]
     steps:
       - name: Decide outcome
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,10 +18,37 @@ jobs:
   set-image:
     uses: ./.github/workflows/set-image.yml
 
+  # Skip expensive jobs when only docs/markdown/non-Rust files changed.
+  # The aggregate gate (basic-checks) always reports, so branch protection
+  # stays safe even when jobs are skipped.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.rust == 'true' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '.config/**'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/check.yml'
+              - '.github/workflows/set-image.yml'
+              - '.github/env'
+
   check-fmt:
     runs-on: parity-default
     timeout-minutes: 20
-    needs: [set-image]
+    needs: [set-image, changes]
+    if: needs.changes.outputs.rust == 'true'
     container:
       image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
@@ -50,7 +77,8 @@ jobs:
   check:
     name: Cargo check
     runs-on: parity-large
-    needs: [set-image]
+    needs: [set-image, changes]
+    if: needs.changes.outputs.rust == 'true'
     container:
       image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
@@ -305,7 +333,7 @@ jobs:
   # of pinning each job (fmt/check/clippy/test/benchmarks) individually.
   basic-checks:
     name: Basic checks
-    needs: [check-fmt, check, clippy, test, benchmarks, coverage]
+    needs: [changes, check-fmt, check, clippy, test, benchmarks, coverage]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,28 @@ jobs:
   set-image:
     uses: ./.github/workflows/set-image.yml
 
+  # Skip expensive jobs when only docs/markdown changed. The aggregate gate
+  # (integration-tests-complete) always reports for branch protection.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.src == 'true' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.claude/**'
+              - '!LICENSE'
+
   # ── Build once ────────────────────────────────────────────────────────────
   # Build the shared artifacts once (provider binary + one compressed wasm per
   # tested runtime) so both test jobs download instead of rebuilding. The test
@@ -26,7 +48,8 @@ jobs:
     name: Build
     runs-on: parity-large
     timeout-minutes: 60
-    needs: [set-image]
+    needs: [set-image, changes]
+    if: needs.changes.outputs.src == 'true'
     container:
       image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
@@ -754,7 +777,7 @@ jobs:
 
   integration-tests-complete:
     name: Integration Tests
-    needs: [build, integration-tests, e2e-integration-tests, sc-integration-tests, ui-integration-tests, coverage-gate]
+    needs: [changes, build, integration-tests, e2e-integration-tests, sc-integration-tests, ui-integration-tests, coverage-gate]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

All CI workflows run on every push/PR regardless of what changed. A README or docs update triggers the full Rust build, integration tests, and runtime migration checks — wasting CI minutes and blocking PRs unnecessarily.

## Solution

Add `dorny/paths-filter` change detection to the three heaviest workflows, using the same pattern already established in `ui-checks.yml`:

| Workflow | Skips when only these change | Always runs on |
|---|---|---|
| `check.yml` | Non-Rust files (docs, markdown, .claude/) | `workflow_dispatch` |
| `integration-tests.yml` | `*.md`, `docs/**`, `.claude/**`, `LICENSE` | `workflow_dispatch` |
| `check-runtime-migration.yml` | Non-runtime/pallet files | `workflow_dispatch`, `schedule` |

### How it works

1. A lightweight `changes` job runs `dorny/paths-filter` to detect what changed
2. Expensive jobs (build, test, clippy, migrations) get `if: needs.changes.outputs.<filter> == 'true'`
3. Downstream jobs auto-skip via dependency chain (e.g. clippy/test/benchmarks depend on `check`)
4. Aggregate gate jobs (`basic-checks`, `Integration Tests`, `All migrations passed`) always report with `if: always()` — so branch protection stays safe even when everything is skipped

### Not changed

- `zizmor.yml` — already lightweight (ubuntu-latest, just a CLI tool)
- `ui-checks.yml` — already has path filtering
- `deploy-ui.yml` — already has top-level `paths` filter

## Test plan

- [ ] A docs-only PR skips Rust checks and integration tests
- [ ] A Rust code PR runs all checks normally
- [ ] `workflow_dispatch` always runs everything
- [ ] Gate jobs always report (branch protection not broken)
- [ ] Scheduled runtime migration snapshots still refresh daily
