### PR TITLE
Nits: v0.3.0-paseo release bump, s3-ui GitHub Pages fixes, CI tweak

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -208,7 +208,9 @@ jobs:
           save-if: false
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        with:
+          tool: cargo-llvm-cov
 
       - name: Measure PR coverage
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9660,7 +9660,7 @@ dependencies = [
 
 [[package]]
 name = "storage-paseo-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -9742,7 +9742,7 @@ dependencies = [
 
 [[package]]
 name = "storage-provider-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/provider-node/Cargo.toml
+++ b/provider-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-provider-node"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/runtimes/web3-storage-paseo/Cargo.toml
+++ b/runtimes/web3-storage-paseo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-paseo-runtime"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/runtimes/web3-storage-paseo/src/lib.rs
+++ b/runtimes/web3-storage-paseo/src/lib.rs
@@ -186,9 +186,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: Cow::Borrowed("paseo-web3-storage-runtime"),
     authoring_version: 1,
     // Encodes the runtime semver: major * 1_000_000 + minor * 1_000 + patch.
-    // 0.2.0 -> 2_000. Must stay > the deployed value so the upgrade is
-    // accepted and migrations run (previous release was `1`).
-    spec_version: 2_000,
+    // 0.3.0 -> 3_000. Must stay > the deployed value so the upgrade is
+    // accepted and migrations run (previous release was `2_000`).
+    spec_version: 3_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/user-interfaces/s3-ui/public/s3-icon.svg
+++ b/user-interfaces/s3-ui/public/s3-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#4f46e5"/>
+  <path d="M9 11H23L21.5 22.5C21.4 23.35 20.68 24 19.82 24H12.18C11.32 24 10.6 23.35 10.5 22.5L9 11Z" stroke="white" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M8 11C8 9.89543 11.5817 9 16 9C20.4183 9 24 9.89543 24 11C24 12.1046 20.4183 13 16 13C11.5817 13 8 12.1046 8 11Z" stroke="white" stroke-width="1.5"/>
+</svg>

--- a/user-interfaces/s3-ui/vite.config.ts
+++ b/user-interfaces/s3-ui/vite.config.ts
@@ -5,7 +5,7 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "path";
 
-const ghBase = process.env.VITE_BASE_PATH || "/";
+const ghBase = process.env.GITHUB_PAGES ? "/web3-storage/s3/" : "/";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],


### PR DESCRIPTION
Small grab-bag of nits on top of `dev`.

## Changes

- **`chore(release): v0.3.0-paseo`** — provider-node `0.2.0 → 0.3.0`, storage-paseo-runtime crate `0.2.0 → 0.3.0`, `RuntimeVersion.spec_version 2_000 → 3_000`. Ships everything since v0.2.0-paseo. No extrinsic encoding changes, so `transaction_version` stays at 2; the spec_version bump triggers any on-chain migrations on upgrade.

- **`fix(s3-ui): use GITHUB_PAGES base path`** — the S3 UI on GitHub Pages rendered a blank white page. The deploy workflow sets `GITHUB_PAGES=true`, which `provider`/`drive-ui` read to set their subpath `base`, but `s3-ui` read a never-set `VITE_BASE_PATH` and fell back to `/`. Its built `index.html` then referenced assets at the site root (`/assets/...`), which 404'd; Firefox refused the HTML-as-module (`disallowed MIME type ("text/html")`) and nothing rendered. Now aligned with the other UIs: base `/web3-storage/s3/` under `GITHUB_PAGES`, `/` otherwise.

- **`fix(s3-ui): add missing s3-icon.svg favicon`** — `index.html` referenced `/s3-icon.svg`, which never existed (404 on every load). Added a bucket-style icon matching the indigo accent (`#4f46e5`) used by the app and the sibling drive-ui icon. Served from `public/` at the configured base.

- **`nit`** — install `cargo-llvm-cov` via the pinned `taiki-e/install-action` instead of `cargo install --locked` in `check.yml` (faster, no source build).

## Notes

Targets `dev` (the default branch); `bko-nits` is a clean fast-forward of `origin/dev`. The Pages fixes take effect on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)