### PR TITLE
fix(s3-ui): resolve TLS provider multiaddrs to https for /negotiate

### DIFF
--- a/user-interfaces/drive-ui/src/components/DriveList.tsx
+++ b/user-interfaces/drive-ui/src/components/DriveList.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useState } from "react";
-import { HardDrive, MoreHorizontal, Plus, Trash2, Users } from "lucide-react";
+import { HardDrive, MoreHorizontal, Plus, Server, Trash2, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -23,6 +23,37 @@ import { toast } from "@/components/ui/toaster";
 import ConfirmDialog from "./ConfirmDialog";
 import NewDriveDialog from "./NewDriveDialog";
 import ManageAccessDialog from "./ManageAccessDialog";
+
+function shortAddress(account: string): string {
+  return `${account.slice(0, 6)}…${account.slice(-4)}`;
+}
+
+function providerHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+/** Primary-provider display parts for a drive: address, optional host, extra count. */
+function providerParts(providers: DriveInfo["providerInfo"]) {
+  const first = providers[0];
+  if (!first) return null;
+  return {
+    addr: shortAddress(first.account),
+    host: first.url ? providerHost(first.url) : null,
+    extra: providers.length - 1,
+  };
+}
+
+/** Full provider details for the hover tooltip — one provider per line. */
+function providerTitle(providers: DriveInfo["providerInfo"]): string {
+  if (providers.length === 0) return "No primary provider";
+  return providers
+    .map((p) => `${p.account}${p.url ? ` — ${p.url}` : p.multiaddr ? ` — ${p.multiaddr}` : ""}`)
+    .join("\n");
+}
 
 export default function DriveList() {
   const drives = useDrives();
@@ -80,6 +111,29 @@ export default function DriveList() {
                     <p className="text-xs text-muted-foreground">
                       {formatBytes(Number(drive.maxCapacity))}
                     </p>
+                    {(() => {
+                      const p = providerParts(drive.providerInfo);
+                      return (
+                        <div
+                          className="flex items-start gap-1 text-xs text-muted-foreground"
+                          title={providerTitle(drive.providerInfo)}
+                          data-testid={`drive-list-provider-${drive.driveId}`}
+                        >
+                          <Server className="h-3 w-3 flex-shrink-0 mt-0.5" />
+                          {p ? (
+                            <span className="flex flex-col min-w-0 leading-tight">
+                              <span className="truncate">
+                                {p.addr}
+                                {p.extra > 0 ? ` +${p.extra}` : ""}
+                              </span>
+                              {p.host && <span className="truncate">{p.host}</span>}
+                            </span>
+                          ) : (
+                            <span className="truncate">No provider</span>
+                          )}
+                        </div>
+                      );
+                    })()}
                   </div>
                   <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                     <button

--- a/user-interfaces/drive-ui/src/components/NewDriveDialog.tsx
+++ b/user-interfaces/drive-ui/src/components/NewDriveDialog.tsx
@@ -63,7 +63,7 @@ function CreationStatusCard({
           )}
         </div>
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium truncate">{item.name}</p>
+          <p className="text-sm font-medium truncate">{item.name || "Untitled Drive"}</p>
           <p className="text-xs text-muted-foreground mt-0.5">
             {item.stage === "submitting" && "Submitting on-chain..."}
             {item.stage === "ready" && "Drive is ready to use"}
@@ -236,9 +236,9 @@ export default function NewDriveDialog({ open, onOpenChange }: NewDriveDialogPro
                     item={item}
                     onDismiss={dismissCreation}
                     onRetry={
-                      canRetryCreation(item.id)
+                      canRetryCreation(item.id) && name.trim()
                         ? (id) => {
-                            void retryCreation(id);
+                            void retryCreation(id, name.trim());
                           }
                         : undefined
                     }

--- a/user-interfaces/drive-ui/src/components/NewDriveDialog.tsx
+++ b/user-interfaces/drive-ui/src/components/NewDriveDialog.tsx
@@ -20,12 +20,8 @@ import {
   useCreations,
   type CreationStatus,
 } from "@/state";
-import {
-  negotiateTerms,
-  parseMultiaddrToHttp,
-  type AvailableProvider,
-  type SignedTerms,
-} from "@/lib/drive-client";
+import { negotiateTerms, type AvailableProvider, type SignedTerms } from "@/lib/drive-client";
+import { parseMultiaddrToUrl } from "@web3-storage/papi";
 import { formatBytes } from "@/lib/utils";
 import ProviderPickerPanel from "./ProviderPickerPanel";
 
@@ -120,7 +116,7 @@ export default function NewDriveDialog({ open, onOpenChange }: NewDriveDialogPro
     setSubmitting(true);
     setNegotiateError(null);
     try {
-      const url = parseMultiaddrToHttp(provider.multiaddr);
+      const url = parseMultiaddrToUrl(provider.multiaddr);
       if (!url) {
         setNegotiateError(
           `Provider ${provider.account} has an unparseable multiaddr: ${provider.multiaddr}`,

--- a/user-interfaces/drive-ui/src/components/NewDriveDialog.tsx
+++ b/user-interfaces/drive-ui/src/components/NewDriveDialog.tsx
@@ -20,8 +20,8 @@ import {
   useCreations,
   type CreationStatus,
 } from "@/state";
-import { negotiateTerms, type AvailableProvider, type SignedTerms } from "@/lib/drive-client";
-import { parseMultiaddrToUrl } from "@web3-storage/papi";
+import { type AvailableProvider } from "@/lib/drive-client";
+import { negotiateProviderTerms } from "@web3-storage/papi";
 import { formatBytes } from "@/lib/utils";
 import ProviderPickerPanel from "./ProviderPickerPanel";
 
@@ -116,14 +116,6 @@ export default function NewDriveDialog({ open, onOpenChange }: NewDriveDialogPro
     setSubmitting(true);
     setNegotiateError(null);
     try {
-      const url = parseMultiaddrToUrl(provider.multiaddr);
-      if (!url) {
-        setNegotiateError(
-          `Provider ${provider.account} has an unparseable multiaddr: ${provider.multiaddr}`,
-        );
-        return;
-      }
-
       const owner = getSignerAddress();
       if (!owner) {
         setNegotiateError("Signer not set");
@@ -131,28 +123,24 @@ export default function NewDriveDialog({ open, onOpenChange }: NewDriveDialogPro
       }
 
       // Failure here means re-negotiate from scratch on retry.
-      let signed: SignedTerms;
-      try {
-        signed = await negotiateTerms(url, {
-          owner,
-          max_bytes: BigInt(capacity),
-          duration: parseInt(duration, 10),
-          price_per_byte: BigInt(pricePerByte || "0"),
-          replica_params: null,
-          bucket_id: null,
-        });
-      } catch (err) {
-        setNegotiateError(
-          err instanceof Error ? err.message : "Failed to negotiate with provider",
-        );
+      const result = await negotiateProviderTerms(provider, {
+        owner,
+        max_bytes: BigInt(capacity),
+        duration: parseInt(duration, 10),
+        price_per_byte: BigInt(pricePerByte || "0"),
+        replica_params: null,
+        bucket_id: null,
+      });
+      if (!result.ok) {
+        setNegotiateError(result.error);
         return;
       }
 
       const drive = await createDrive({
         name: name || undefined,
         provider,
-        url,
-        signed,
+        url: result.url,
+        signed: result.signed,
       });
       if (drive) {
         setName("");

--- a/user-interfaces/drive-ui/src/lib/drive-client.ts
+++ b/user-interfaces/drive-ui/src/lib/drive-client.ts
@@ -9,7 +9,10 @@
 
 import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPayload } from "polkadot-api";
 import { parachain } from "@polkadot-api/descriptors";
-import { resolveProviderEndpoint, toSs58 } from "@web3-storage/papi";
+import { resolveProviderEndpoint, toSs58, type SignedTerms } from "@web3-storage/papi";
+
+// Re-exported so state modules can keep importing it from the client facade.
+export type { SignedTerms } from "@web3-storage/papi";
 import type { ParachainApi } from "@/state/chain.state";
 
 export type Signer = PolkadotSigner;
@@ -29,33 +32,6 @@ export interface DriveInfo {
   expiresAt: number;
 }
 
-/**
- * Provider-signed agreement terms returned by `POST /negotiate` on the
- * provider node. The signature is the SCALE-encoded `MultiSignature` as
- * hex (e.g. `0x01<64-byte-sr25519-sig>`).
- */
-export interface SignedTerms {
-  terms: {
-    owner: string;
-    max_bytes: number | bigint;
-    duration: number;
-    price_per_byte: number | bigint;
-    valid_until: number;
-    nonce: number | bigint;
-    replica_params: unknown | null;
-    bucket_id: bigint | null;
-  };
-  signature: string;
-}
-
-export interface NegotiateRequest {
-  owner: string;
-  max_bytes: number | bigint;
-  duration: number;
-  price_per_byte: number | bigint;
-  replica_params: unknown | null;
-  bucket_id?: bigint | null;
-}
 
 export interface AvailableProvider {
   account: string;
@@ -190,28 +166,6 @@ function decodeName(name: unknown): string | null {
   } catch {
     return null;
   }
-}
-
-/**
- * POST a `NegotiateRequest` to the provider's `/negotiate` endpoint and
- * return the provider-signed terms bundle.
- */
-export async function negotiateTerms(
-  providerUrl: string,
-  request: NegotiateRequest,
-): Promise<SignedTerms> {
-  const res = await fetch(`${providerUrl.replace(/\/$/, "")}/negotiate`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(request, (_k, v) =>
-      typeof v === "bigint" ? v.toString() : v,
-    ),
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`/negotiate failed: ${res.status} ${body}`);
-  }
-  return res.json();
 }
 
 // MultiSignature SCALE variant order from sp_runtime.

--- a/user-interfaces/drive-ui/src/lib/drive-client.ts
+++ b/user-interfaces/drive-ui/src/lib/drive-client.ts
@@ -9,7 +9,7 @@
 
 import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPayload } from "polkadot-api";
 import { parachain } from "@polkadot-api/descriptors";
-import { resolveProviderEndpoint, toSs58, type SignedTerms } from "@web3-storage/papi";
+import { parseMultiaddrToUrl, resolveProviderEndpoint, toSs58, type SignedTerms } from "@web3-storage/papi";
 
 // Re-exported so state modules can keep importing it from the client facade.
 export type { SignedTerms } from "@web3-storage/papi";
@@ -19,6 +19,14 @@ export type Signer = PolkadotSigner;
 
 const HTTP_RETRY_ATTEMPTS = 3;
 const HTTP_RETRY_BASE_MS = 250;
+
+/** A primary provider backing a drive's underlying layer-0 bucket. */
+export interface DriveProviderInfo {
+  account: string;
+  multiaddr: string;
+  /** Resolved HTTP(S) base URL, or `null` if the multiaddr isn't an HTTP endpoint. */
+  url: string | null;
+}
 
 export interface DriveInfo {
   driveId: bigint;
@@ -30,8 +38,16 @@ export interface DriveInfo {
   createdAt: number;
   storagePeriod: number;
   expiresAt: number;
+  /** Primary providers of the underlying layer-0 bucket. */
+  providerInfo: DriveProviderInfo[];
 }
 
+
+/**
+ * Provider-signed agreement terms returned by `POST /negotiate` on the
+ * provider node. The signature is the SCALE-encoded `MultiSignature` as
+ * hex (e.g. `0x01<64-byte-sr25519-sig>`).
+ */
 
 export interface AvailableProvider {
   account: string;
@@ -461,6 +477,7 @@ export class DriveClient {
       createdAt: 0,
       storagePeriod: signed.terms.duration,
       expiresAt: 0,
+      providerInfo: [{ account: providerAccount, multiaddr: "", url: providerUrl }],
     };
   }
 
@@ -471,12 +488,17 @@ export class DriveClient {
     const driveIds = await api.query.DriveRegistry.UserDrives.getValue(address);
     if (driveIds.length === 0) return [];
 
+    // Batch all drive lookups into one storage query instead of N round-trips.
+    const driveValues = await api.query.DriveRegistry.Drives.getValues(
+      driveIds.map((driveId) => [driveId] as const),
+    );
+
     const drives: DriveInfo[] = [];
-    for (const driveId of driveIds) {
-      const drive = await api.query.DriveRegistry.Drives.getValue(driveId);
-      if (!drive) continue;
+    const bucketIds: bigint[] = [];
+    driveValues.forEach((drive, i) => {
+      if (!drive) return;
       drives.push({
-        driveId,
+        driveId: driveIds[i]!,
         bucketId: drive.bucket_id,
         owner: drive.owner,
         name: decodeName(drive.name),
@@ -484,8 +506,17 @@ export class DriveClient {
         createdAt: drive.created_at,
         storagePeriod: drive.storage_period,
         expiresAt: drive.expires_at,
+        providerInfo: [],
       });
-    }
+      bucketIds.push(drive.bucket_id);
+    });
+
+    // `providersByBucket[i]` aligns with `drives[i]` (both built skipping nulls).
+    const providersByBucket = await this.resolveBucketProviders(bucketIds);
+    drives.forEach((drive, i) => {
+      drive.providerInfo = providersByBucket[i] ?? [];
+    });
+
     return drives;
   }
 
@@ -493,6 +524,7 @@ export class DriveClient {
     const api = this.requireApi();
     const drive = await api.query.DriveRegistry.Drives.getValue(driveId);
     if (!drive) return null;
+    const [providerInfo] = await this.resolveBucketProviders([drive.bucket_id]);
     return {
       driveId,
       bucketId: drive.bucket_id,
@@ -502,7 +534,47 @@ export class DriveClient {
       createdAt: drive.created_at,
       storagePeriod: drive.storage_period,
       expiresAt: drive.expires_at,
+      providerInfo: providerInfo ?? [],
     };
+  }
+
+  /**
+   * Resolve the primary-provider info for each given layer-0 bucket id, batching
+   * every storage read into a single query per pallet map (no per-bucket /
+   * per-provider round-trips). Returns an array aligned with `bucketIds`.
+   */
+  private async resolveBucketProviders(
+    bucketIds: bigint[],
+  ): Promise<DriveProviderInfo[][]> {
+    const api = this.requireApi();
+    const bucketInfo = await api.query.StorageProvider.Buckets.getValues(
+      bucketIds.map((id) => [id] as const),
+    );
+
+    const providerAccounts = [
+      ...new Set(bucketInfo.flatMap((info) => info?.primary_providers ?? [])),
+    ];
+    const providerRecords = await api.query.StorageProvider.Providers.getValues(
+      providerAccounts.map((account) => [account] as const),
+    );
+
+    const providerMap = new Map<string, DriveProviderInfo>();
+    providerAccounts.forEach((account, i) => {
+      const record = providerRecords[i];
+      if (!record) return;
+      const multiaddr = new TextDecoder().decode(record.multiaddr);
+      providerMap.set(account, {
+        account,
+        multiaddr,
+        url: parseMultiaddrToUrl(multiaddr),
+      });
+    });
+
+    return bucketInfo.map((info) =>
+      (info?.primary_providers ?? [])
+        .map((account) => providerMap.get(account))
+        .filter((p): p is DriveProviderInfo => p != null),
+    );
   }
 
   async deleteDrive(driveId: bigint): Promise<void> {

--- a/user-interfaces/drive-ui/src/lib/drive-client.ts
+++ b/user-interfaces/drive-ui/src/lib/drive-client.ts
@@ -270,29 +270,6 @@ export function buildSignedTermsArgs(
   return { provider: providerAccount, terms, sig };
 }
 
-export function parseMultiaddrToHttp(multiaddr: string): string | null {
-  const parts = multiaddr.split("/").filter(Boolean);
-  let host: string | null = null;
-  let port: string | null = null;
-
-  for (let i = 0; i < parts.length; i++) {
-    const seg = parts[i];
-    const next = parts[i + 1];
-    if (!next) continue;
-
-    if ((seg === "ip4" || seg === "ip6" || seg === "dns4" || seg === "dns6") && host === null) {
-      host = seg.startsWith("ip6") ? `[${next}]` : next;
-    }
-    if (seg === "tcp" && port === null) {
-      port = next;
-    }
-    if (host !== null && port !== null) break;
-  }
-
-  if (host && port) return `http://${host}:${port}`;
-  return null;
-}
-
 export class DriveClient {
   private api: ParachainApi | null = null;
   private signer: Signer | null = null;

--- a/user-interfaces/drive-ui/src/lib/drive-client.ts
+++ b/user-interfaces/drive-ui/src/lib/drive-client.ts
@@ -9,16 +9,20 @@
 
 import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPayload } from "polkadot-api";
 import { parachain } from "@polkadot-api/descriptors";
-import { resolveProviderEndpoint, toSs58, type SignedTerms } from "@web3-storage/papi";
+import {
+  buildSignedTermsArgs,
+  httpFetch,
+  resolveProviderEndpoint,
+  toSs58,
+  type SignedTerms,
+} from "@web3-storage/papi";
 
-// Re-exported so state modules can keep importing it from the client facade.
+// Re-exported so other modules can keep importing them from the client facade.
+export { buildSignedTermsArgs } from "@web3-storage/papi";
 export type { SignedTerms } from "@web3-storage/papi";
 import type { ParachainApi } from "@/state/chain.state";
 
 export type Signer = PolkadotSigner;
-
-const HTTP_RETRY_ATTEMPTS = 3;
-const HTTP_RETRY_BASE_MS = 250;
 
 export interface DriveInfo {
   driveId: bigint;
@@ -119,43 +123,6 @@ export interface QueryMatchingProvidersParams {
   limit: number;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-function isAbortError(err: unknown): boolean {
-  return (
-    err instanceof DOMException &&
-    (err.name === "AbortError" || err.code === DOMException.ABORT_ERR)
-  );
-}
-
-function isRetryableHttpError(status: number | null): boolean {
-  if (status === null) return true;
-  return status >= 500 && status < 600;
-}
-
-async function httpFetch(
-  url: string,
-  init: RequestInit & { signal?: AbortSignal } = {},
-): Promise<Response> {
-  let lastError: unknown = null;
-  for (let attempt = 0; attempt < HTTP_RETRY_ATTEMPTS; attempt++) {
-    try {
-      const res = await fetch(url, init);
-      if (res.ok || !isRetryableHttpError(res.status)) return res;
-      lastError = new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
-    } catch (err) {
-      if (isAbortError(err)) throw err;
-      lastError = err;
-    }
-    if (attempt < HTTP_RETRY_ATTEMPTS - 1) {
-      await sleep(HTTP_RETRY_BASE_MS * Math.pow(2, attempt));
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error("HTTP request failed");
-}
-
 function decodeName(name: unknown): string | null {
   if (name == null) return null;
   try {
@@ -166,62 +133,6 @@ function decodeName(name: unknown): string | null {
   } catch {
     return null;
   }
-}
-
-// MultiSignature SCALE variant order from sp_runtime.
-const MULTI_SIGNATURE_VARIANT: Record<number, string> = {
-  0: "Ed25519",
-  1: "Sr25519",
-  2: "Ecdsa",
-  3: "Eth",
-};
-
-function hexToBytes(hex: string): Uint8Array {
-  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
-  const out = new Uint8Array(h.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16);
-  }
-  return out;
-}
-
-/**
- * Build the `{ provider, terms, sig }` args shared by every signed-terms
- * extrinsic.
- */
-export function buildSignedTermsArgs(
-  providerAccount: string,
-  signed: SignedTerms,
-) {
-  const sigBytes = hexToBytes(signed.signature);
-  if (sigBytes.length < 1) {
-    throw new Error("signature too short to contain a MultiSignature variant byte");
-  }
-  const variantName = MULTI_SIGNATURE_VARIANT[sigBytes[0]];
-  if (!variantName) {
-    throw new Error(`unknown MultiSignature variant byte: ${sigBytes[0]}`);
-  }
-  const sigPayloadHex =
-    "0x" +
-    Array.from(sigBytes.slice(1))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sig = Enum(variantName as any, sigPayloadHex);
-
-  const t = signed.terms;
-  const terms = {
-    owner: t.owner,
-    max_bytes: BigInt(t.max_bytes),
-    duration: t.duration,
-    price_per_byte: BigInt(t.price_per_byte),
-    valid_until: t.valid_until,
-    nonce: BigInt(t.nonce),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    replica_params: (t.replica_params ?? undefined) as any,
-    bucket_id: t.bucket_id ? BigInt(t.bucket_id) : undefined,
-  };
-  return { provider: providerAccount, terms, sig };
 }
 
 export class DriveClient {

--- a/user-interfaces/drive-ui/src/state/drive.state.ts
+++ b/user-interfaces/drive-ui/src/state/drive.state.ts
@@ -312,7 +312,6 @@ export function dismissCreation(id: string): void {
 }
 
 interface RetryCtx {
-  name: string | undefined;
   provider: AvailableProvider;
   url: string;
   signed: SignedTerms;
@@ -326,7 +325,10 @@ export function canRetryCreation(id: string): boolean {
 async function runChainSubmit(id: string, ctx: RetryCtx): Promise<DriveInfo | null> {
   updateCreation(id, { stage: "submitting", error: undefined });
   try {
-    const drive = await client.submitCreateDrive(ctx.name, ctx.provider.account, ctx.url, ctx.signed);
+    // Name lives on the creation record (keyed by id), not the retry context.
+    // Empty string is treated as "no name" by submitCreateDrive.
+    const name = creations$.getValue().find((c) => c.id === id)?.name || undefined;
+    const drive = await client.submitCreateDrive(name, ctx.provider.account, ctx.url, ctx.signed);
     updateCreation(id, { stage: "ready", bucketId: drive.bucketId });
     retryCtx.delete(id);
     await refreshDrives();
@@ -347,16 +349,16 @@ export async function createDrive(input: CreateDriveInput): Promise<DriveInfo | 
   if (!client.hasApi() || !client.hasSigner()) return null;
 
   const id = crypto.randomUUID();
-  const displayName = input.name || "Untitled Drive";
   creations$.next([
     ...creations$.getValue(),
-    { id, name: displayName, stage: "submitting", elapsedMs: 0 },
+    // Store the raw name; the "Untitled Drive" fallback is applied at render.
+    { id, name: input.name ?? "", stage: "submitting", elapsedMs: 0 },
   ]);
 
   // Terms are negotiated by the caller; this only does the chain submit.
   // Stash retry context first so a failure leaves a retry handle attached
   // to the CreationStatus.
-  const ctx: RetryCtx = { name: input.name, provider: input.provider, url: input.url, signed: input.signed };
+  const ctx: RetryCtx = { provider: input.provider, url: input.url, signed: input.signed };
   retryCtx.set(id, ctx);
   return runChainSubmit(id, ctx);
 }
@@ -365,9 +367,15 @@ export async function createDrive(input: CreateDriveInput): Promise<DriveInfo | 
  * Retry a failed on-chain submit using the cached signed terms. No-op if
  * the creation expired or never negotiated successfully.
  */
-export async function retryCreation(id: string): Promise<DriveInfo | null> {
+export async function retryCreation(
+  id: string,
+  name?: string,
+): Promise<DriveInfo | null> {
   const ctx = retryCtx.get(id);
   if (!ctx) return null;
+  // Let the caller override the name on retry (e.g. from the current input).
+  // runChainSubmit reads the name back off the creation record.
+  if (name !== undefined) updateCreation(id, { name });
   return runChainSubmit(id, ctx);
 }
 

--- a/user-interfaces/pnpm-lock.yaml
+++ b/user-interfaces/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
       '@polkadot-api/descriptors':
         specifier: file:.papi/descriptors
         version: file:shared/papi/.papi/descriptors(polkadot-api@2.1.6(esbuild@0.28.0)(rxjs@7.8.2))
+      '@polkadot-api/utils':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@polkadot-labs/hdkd-helpers':
         specifier: ^0.0.30
         version: 0.0.30

--- a/user-interfaces/s3-ui/src/components/BucketList.tsx
+++ b/user-interfaces/s3-ui/src/components/BucketList.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useState } from "react";
-import { Archive, MoreHorizontal, Plus, Trash2, Users } from "lucide-react";
+import { Archive, MoreHorizontal, Plus, Server, Trash2, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -22,6 +22,37 @@ import { toast } from "@/components/ui/toaster";
 import ConfirmDialog from "./ConfirmDialog";
 import NewBucketDialog from "./NewBucketDialog";
 import ManageAccessDialog from "./ManageAccessDialog";
+
+function shortAddress(account: string): string {
+  return `${account.slice(0, 6)}…${account.slice(-4)}`;
+}
+
+function providerHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+/** Primary-provider display parts for a bucket: address, optional host, extra count. */
+function providerParts(providers: BucketInfo["providerInfo"]) {
+  const first = providers[0];
+  if (!first) return null;
+  return {
+    addr: shortAddress(first.account),
+    host: first.url ? providerHost(first.url) : null,
+    extra: providers.length - 1,
+  };
+}
+
+/** Full provider details for the hover tooltip — one provider per line. */
+function providerTitle(providers: BucketInfo["providerInfo"]): string {
+  if (providers.length === 0) return "No primary provider";
+  return providers
+    .map((p) => `${p.account}${p.url ? ` — ${p.url}` : p.multiaddr ? ` — ${p.multiaddr}` : ""}`)
+    .join("\n");
+}
 
 export default function BucketList() {
   const buckets = useBuckets();
@@ -79,6 +110,29 @@ export default function BucketList() {
                     <p className="text-xs text-muted-foreground">
                       ID: {bucket.s3BucketId.toString()}
                     </p>
+                    {(() => {
+                      const p = providerParts(bucket.providerInfo);
+                      return (
+                        <div
+                          className="flex items-start gap-1 text-xs text-muted-foreground"
+                          title={providerTitle(bucket.providerInfo)}
+                          data-testid={`bucket-list-provider-${bucket.s3BucketId}`}
+                        >
+                          <Server className="h-3 w-3 flex-shrink-0 mt-0.5" />
+                          {p ? (
+                            <span className="flex flex-col min-w-0 leading-tight">
+                              <span className="truncate">
+                                {p.addr}
+                                {p.extra > 0 ? ` +${p.extra}` : ""}
+                              </span>
+                              {p.host && <span className="truncate">{p.host}</span>}
+                            </span>
+                          ) : (
+                            <span className="truncate">No provider</span>
+                          )}
+                        </div>
+                      );
+                    })()}
                   </div>
                   <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                     <button

--- a/user-interfaces/s3-ui/src/components/Layout.tsx
+++ b/user-interfaces/s3-ui/src/components/Layout.tsx
@@ -73,6 +73,7 @@ export default function Layout() {
             networkList={networks}
             onSelect={(id) => { void selectNetwork(id); }}
             onSelectCustom={(input) => { void selectCustomNetwork(input); }}
+            theme="light"
           />
         </div>
 

--- a/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
+++ b/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
@@ -239,9 +239,9 @@ export default function NewBucketDialog({ open, onOpenChange }: NewBucketDialogP
                   item={item}
                   onDismiss={dismissCreation}
                   onRetry={
-                    canRetryCreation(item.id)
+                    canRetryCreation(item.id) && name.trim()
                       ? (id) => {
-                          void retryCreation(id);
+                          void retryCreation(id, name.trim());
                         }
                       : undefined
                   }

--- a/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
+++ b/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
@@ -21,13 +21,11 @@ import {
   type CreationStatus,
 } from "@/state";
 import {
-  negotiateTerms,
   type AvailableProvider,
-  type SignedTerms,
 } from "@/lib/s3-client";
 import { formatBytes } from "@/lib/utils";
 import ProviderPickerPanel from "./ProviderPickerPanel";
-import { parseMultiaddrToUrl } from '@web3-storage/papi';
+import { negotiateProviderTerms, parseMultiaddrToUrl } from '@web3-storage/papi';
 
 interface NewBucketDialogProps {
   open: boolean;

--- a/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
+++ b/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
@@ -20,8 +20,8 @@ import {
   useCreations,
   type CreationStatus,
 } from "@/state";
-import { negotiateTerms, type AvailableProvider, type SignedTerms } from "@/lib/s3-client";
-import { parseMultiaddrToUrl } from "@web3-storage/papi";
+import { type AvailableProvider } from "@/lib/s3-client";
+import { negotiateProviderTerms } from "@web3-storage/papi";
 import { formatBytes } from "@/lib/utils";
 import ProviderPickerPanel from "./ProviderPickerPanel";
 
@@ -111,42 +111,30 @@ export default function NewBucketDialog({ open, onOpenChange }: NewBucketDialogP
     setSubmitting(true);
     setNegotiateError(null);
     try {
-      const url = parseMultiaddrToUrl(provider.multiaddr);
-      if (!url) {
-        setNegotiateError(
-          `Provider ${provider.account} has an unparseable multiaddr: ${provider.multiaddr}`,
-        );
-        return;
-      }
-
       const owner = getSignerAddress();
       if (!owner) {
         setNegotiateError("Signer not set");
         return;
       }
 
-      let signed: SignedTerms;
-      try {
-        signed = await negotiateTerms(url, {
-          owner,
-          max_bytes: BigInt(capacity),
-          duration: parseInt(duration, 10),
-          price_per_byte: BigInt(pricePerByte || "0"),
-          replica_params: null,
-          bucket_id: null,
-        });
-      } catch (err) {
-        setNegotiateError(
-          err instanceof Error ? err.message : "Failed to negotiate with provider",
-        );
+      const result = await negotiateProviderTerms(provider, {
+        owner,
+        max_bytes: BigInt(capacity),
+        duration: parseInt(duration, 10),
+        price_per_byte: BigInt(pricePerByte || "0"),
+        replica_params: null,
+        bucket_id: null,
+      });
+      if (!result.ok) {
+        setNegotiateError(result.error);
         return;
       }
 
       const bucket = await createBucket({
         name: name || "Untitled Bucket",
         provider,
-        url,
-        signed,
+        url: result.url,
+        signed: result.signed,
       });
       if (bucket) {
         setName("");

--- a/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
+++ b/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
@@ -20,10 +20,14 @@ import {
   useCreations,
   type CreationStatus,
 } from "@/state";
-import { type AvailableProvider } from "@/lib/s3-client";
-import { negotiateProviderTerms } from "@web3-storage/papi";
+import {
+  negotiateTerms,
+  type AvailableProvider,
+  type SignedTerms,
+} from "@/lib/s3-client";
 import { formatBytes } from "@/lib/utils";
 import ProviderPickerPanel from "./ProviderPickerPanel";
+import { parseMultiaddrToUrl } from '@web3-storage/papi';
 
 interface NewBucketDialogProps {
   open: boolean;
@@ -111,6 +115,14 @@ export default function NewBucketDialog({ open, onOpenChange }: NewBucketDialogP
     setSubmitting(true);
     setNegotiateError(null);
     try {
+      const url = parseMultiaddrToUrl(provider.multiaddr);
+      if (!url) {
+        setNegotiateError(
+          `Provider ${provider.account} has an unparseable multiaddr: ${provider.multiaddr}`,
+        );
+        return;
+      }
+
       const owner = getSignerAddress();
       if (!owner) {
         setNegotiateError("Signer not set");

--- a/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
+++ b/user-interfaces/s3-ui/src/components/NewBucketDialog.tsx
@@ -20,12 +20,8 @@ import {
   useCreations,
   type CreationStatus,
 } from "@/state";
-import {
-  negotiateTerms,
-  parseMultiaddrToHttp,
-  type AvailableProvider,
-  type SignedTerms,
-} from "@/lib/s3-client";
+import { negotiateTerms, type AvailableProvider, type SignedTerms } from "@/lib/s3-client";
+import { parseMultiaddrToUrl } from "@web3-storage/papi";
 import { formatBytes } from "@/lib/utils";
 import ProviderPickerPanel from "./ProviderPickerPanel";
 
@@ -115,7 +111,7 @@ export default function NewBucketDialog({ open, onOpenChange }: NewBucketDialogP
     setSubmitting(true);
     setNegotiateError(null);
     try {
-      const url = parseMultiaddrToHttp(provider.multiaddr);
+      const url = parseMultiaddrToUrl(provider.multiaddr);
       if (!url) {
         setNegotiateError(
           `Provider ${provider.account} has an unparseable multiaddr: ${provider.multiaddr}`,

--- a/user-interfaces/s3-ui/src/lib/s3-client.ts
+++ b/user-interfaces/s3-ui/src/lib/s3-client.ts
@@ -9,7 +9,15 @@
 import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPayload } from "polkadot-api";
 import { Subscription } from "rxjs";
 import { parachain } from "@polkadot-api/descriptors";
-import { resolveProviderEndpoint, toSs58, type ParachainApi } from "@web3-storage/papi";
+import {
+  resolveProviderEndpoint,
+  toSs58,
+  type ParachainApi,
+  type SignedTerms,
+} from "@web3-storage/papi";
+
+// Re-exported so state modules can keep importing it from the client facade.
+export type { SignedTerms } from "@web3-storage/papi";
 
 export type Signer = PolkadotSigner;
 
@@ -36,29 +44,6 @@ export interface S3ObjectInfo {
 export interface UploadResult {
   cid: string;
   size: number;
-}
-
-export interface SignedTerms {
-  terms: {
-    owner: string;
-    max_bytes: number | bigint;
-    duration: number;
-    price_per_byte: number | bigint;
-    valid_until: number;
-    nonce: number | bigint;
-    replica_params: unknown | null;
-    bucket_id: bigint | null;
-  };
-  signature: string;
-}
-
-export interface NegotiateRequest {
-  owner: string;
-  max_bytes: number | bigint;
-  duration: number;
-  price_per_byte: number | bigint;
-  replica_params: unknown | null;
-  bucket_id?: bigint | null;
 }
 
 export interface AvailableProvider {
@@ -251,24 +236,6 @@ export function buildSignedTermsArgs(
     bucket_id: t.bucket_id ? BigInt(t.bucket_id) : undefined,
   };
   return { provider: providerAccount, terms, sig };
-}
-
-export async function negotiateTerms(
-  providerUrl: string,
-  request: NegotiateRequest,
-): Promise<SignedTerms> {
-  const res = await fetch(`${providerUrl.replace(/\/$/, "")}/negotiate`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(request, (_k, v) =>
-      typeof v === "bigint" ? v.toString() : v,
-    ),
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`/negotiate failed: ${res.status} ${body}`);
-  }
-  return res.json();
 }
 
 function decodeName(name: unknown): string {

--- a/user-interfaces/s3-ui/src/lib/s3-client.ts
+++ b/user-interfaces/s3-ui/src/lib/s3-client.ts
@@ -10,19 +10,20 @@ import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPa
 import { Subscription } from "rxjs";
 import { parachain } from "@polkadot-api/descriptors";
 import {
+  buildSignedTermsArgs,
+  httpFetch,
   resolveProviderEndpoint,
+  toHex,
   toSs58,
   type ParachainApi,
   type SignedTerms,
 } from "@web3-storage/papi";
 
-// Re-exported so state modules can keep importing it from the client facade.
+// Re-exported so other modules can keep importing them from the client facade.
+export { buildSignedTermsArgs } from "@web3-storage/papi";
 export type { SignedTerms } from "@web3-storage/papi";
 
 export type Signer = PolkadotSigner;
-
-const HTTP_RETRY_ATTEMPTS = 3;
-const HTTP_RETRY_BASE_MS = 250;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -141,102 +142,6 @@ export interface QueryMatchingProvidersParams {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-function isAbortError(err: unknown): boolean {
-  return (
-    err instanceof DOMException &&
-    (err.name === "AbortError" || err.code === DOMException.ABORT_ERR)
-  );
-}
-
-function isRetryableHttpError(status: number | null): boolean {
-  if (status === null) return true;
-  return status >= 500 && status < 600;
-}
-
-async function httpFetch(
-  url: string,
-  init: RequestInit & { signal?: AbortSignal } = {},
-): Promise<Response> {
-  let lastError: unknown = null;
-  for (let attempt = 0; attempt < HTTP_RETRY_ATTEMPTS; attempt++) {
-    try {
-      const res = await fetch(url, init);
-      if (res.ok || !isRetryableHttpError(res.status)) return res;
-      lastError = new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
-    } catch (err) {
-      if (isAbortError(err)) throw err;
-      lastError = err;
-    }
-    if (attempt < HTTP_RETRY_ATTEMPTS - 1) {
-      await sleep(HTTP_RETRY_BASE_MS * Math.pow(2, attempt));
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error("HTTP request failed");
-}
-
-function hexToBytes(hex: string): Uint8Array {
-  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
-  const out = new Uint8Array(h.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16);
-  }
-  return out;
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-// MultiSignature SCALE variant order from sp_runtime.
-const MULTI_SIGNATURE_VARIANT: Record<number, string> = {
-  0: "Ed25519",
-  1: "Sr25519",
-  2: "Ecdsa",
-  3: "Eth",
-};
-
-export function buildSignedTermsArgs(
-  providerAccount: string,
-  signed: SignedTerms,
-) {
-  const sigBytes = hexToBytes(signed.signature);
-  if (sigBytes.length < 1) {
-    throw new Error("signature too short to contain a MultiSignature variant byte");
-  }
-  const variantByte = sigBytes[0]!;
-  const variantName = MULTI_SIGNATURE_VARIANT[variantByte];
-  if (!variantName) {
-    throw new Error(`unknown MultiSignature variant byte: ${variantByte}`);
-  }
-  const sigPayloadHex =
-    "0x" +
-    Array.from(sigBytes.slice(1))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sig = Enum(variantName as any, sigPayloadHex);
-
-  const t = signed.terms;
-  const terms = {
-    owner: t.owner,
-    max_bytes: BigInt(t.max_bytes),
-    duration: t.duration,
-    price_per_byte: BigInt(t.price_per_byte),
-    valid_until: t.valid_until,
-    nonce: BigInt(t.nonce),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    replica_params: (t.replica_params ?? undefined) as any,
-    bucket_id: t.bucket_id ? BigInt(t.bucket_id) : undefined,
-  };
-  return { provider: providerAccount, terms, sig };
-}
 
 function decodeName(name: unknown): string {
   if (name == null) return "";
@@ -405,8 +310,8 @@ export class S3Client {
     const message = `web3storage:${method}:${Number(bucketId)}:${timestamp}`;
     const msgBytes = new TextEncoder().encode(message);
     const sig = this.keypair.sign(msgBytes);
-    const pubHex = bytesToHex(this.keypair.publicKey);
-    const sigHex = bytesToHex(sig);
+    const pubHex = toHex(this.keypair.publicKey);
+    const sigHex = toHex(sig);
     return { Authorization: `Web3Storage ${pubHex}:${sigHex}:${timestamp}` };
   }
 

--- a/user-interfaces/s3-ui/src/lib/s3-client.ts
+++ b/user-interfaces/s3-ui/src/lib/s3-client.ts
@@ -11,6 +11,7 @@ import { Subscription } from "rxjs";
 import { parachain } from "@polkadot-api/descriptors";
 import {
   NegotiateRequest,
+  parseMultiaddrToUrl,
   resolveProviderEndpoint,
   toSs58,
   type ParachainApi,

--- a/user-interfaces/s3-ui/src/lib/s3-client.ts
+++ b/user-interfaces/s3-ui/src/lib/s3-client.ts
@@ -9,12 +9,7 @@
 import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPayload } from "polkadot-api";
 import { Subscription } from "rxjs";
 import { parachain } from "@polkadot-api/descriptors";
-import {
-  parseMultiaddrToUrl,
-  resolveProviderEndpoint,
-  toSs58,
-  type ParachainApi,
-} from "@web3-storage/papi";
+import { resolveProviderEndpoint, toSs58, type ParachainApi } from "@web3-storage/papi";
 
 export type Signer = PolkadotSigner;
 
@@ -256,13 +251,6 @@ export function buildSignedTermsArgs(
     bucket_id: t.bucket_id ? BigInt(t.bucket_id) : undefined,
   };
   return { provider: providerAccount, terms, sig };
-}
-
-// Delegates to the shared multiaddr parser so `/tls/`-terminated hosted
-// providers resolve to `https://` (not `http://:443`, which a browser blocks as
-// mixed content on the HTTPS-served UI). See `parseMultiaddrToUrl`.
-export function parseMultiaddrToHttp(multiaddr: string): string | null {
-  return parseMultiaddrToUrl(multiaddr);
 }
 
 export async function negotiateTerms(

--- a/user-interfaces/s3-ui/src/lib/s3-client.ts
+++ b/user-interfaces/s3-ui/src/lib/s3-client.ts
@@ -9,7 +9,12 @@
 import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPayload } from "polkadot-api";
 import { Subscription } from "rxjs";
 import { parachain } from "@polkadot-api/descriptors";
-import { resolveProviderEndpoint, toSs58, type ParachainApi } from "@web3-storage/papi";
+import {
+  parseMultiaddrToUrl,
+  resolveProviderEndpoint,
+  toSs58,
+  type ParachainApi,
+} from "@web3-storage/papi";
 
 export type Signer = PolkadotSigner;
 
@@ -253,27 +258,11 @@ export function buildSignedTermsArgs(
   return { provider: providerAccount, terms, sig };
 }
 
+// Delegates to the shared multiaddr parser so `/tls/`-terminated hosted
+// providers resolve to `https://` (not `http://:443`, which a browser blocks as
+// mixed content on the HTTPS-served UI). See `parseMultiaddrToUrl`.
 export function parseMultiaddrToHttp(multiaddr: string): string | null {
-  const parts = multiaddr.split("/").filter(Boolean);
-  let host: string | null = null;
-  let port: string | null = null;
-
-  for (let i = 0; i < parts.length; i++) {
-    const seg = parts[i];
-    const next = parts[i + 1];
-    if (!next) continue;
-
-    if ((seg === "ip4" || seg === "ip6" || seg === "dns4" || seg === "dns6") && host === null) {
-      host = seg.startsWith("ip6") ? `[${next}]` : next;
-    }
-    if (seg === "tcp" && port === null) {
-      port = next;
-    }
-    if (host !== null && port !== null) break;
-  }
-
-  if (host && port) return `http://${host}:${port}`;
-  return null;
+  return parseMultiaddrToUrl(multiaddr);
 }
 
 export async function negotiateTerms(

--- a/user-interfaces/s3-ui/src/lib/s3-client.ts
+++ b/user-interfaces/s3-ui/src/lib/s3-client.ts
@@ -10,6 +10,7 @@ import { Binary, Enum, type PolkadotSigner, type Transaction, type TxFinalizedPa
 import { Subscription } from "rxjs";
 import { parachain } from "@polkadot-api/descriptors";
 import {
+  NegotiateRequest,
   resolveProviderEndpoint,
   toSs58,
   type ParachainApi,
@@ -26,12 +27,22 @@ const HTTP_RETRY_BASE_MS = 250;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/** A primary provider backing a bucket's underlying layer-0 bucket. */
+export interface BucketProviderInfo {
+  account: string;
+  multiaddr: string;
+  /** Resolved HTTP(S) base URL, or `null` if the multiaddr isn't an HTTP endpoint. */
+  url: string | null;
+}
+
 export interface BucketInfo {
   s3BucketId: bigint;
   name: string;
   layer0BucketId: bigint;
   owner: string;
   createdAt: bigint;
+  /** Primary providers of the underlying layer-0 bucket. */
+  providerInfo: BucketProviderInfo[];
 }
 
 export interface S3ObjectInfo {
@@ -238,6 +249,24 @@ export function buildSignedTermsArgs(
   return { provider: providerAccount, terms, sig };
 }
 
+export async function negotiateTerms(
+  providerUrl: string,
+  request: NegotiateRequest,
+): Promise<SignedTerms> {
+  const res = await fetch(`${providerUrl.replace(/\/$/, "")}/negotiate`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(request, (_k, v) =>
+      typeof v === "bigint" ? v.toString() : v,
+    ),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`/negotiate failed: ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
 function decodeName(name: unknown): string {
   if (name == null) return "";
   try {
@@ -366,6 +395,13 @@ export class S3Client {
       layer0BucketId: layer0_bucket_id,
       owner: address,
       createdAt: 0n,
+      providerInfo: [
+        {
+          account: providerAccount,
+          multiaddr: "",
+          url: providerUrl,
+        },
+      ],
     };
   }
 
@@ -376,18 +412,57 @@ export class S3Client {
     const bucketIds = await api.query.S3Registry.UserBuckets.getValue(address);
     if (bucketIds.length === 0) return [];
 
+    const bucketValues = await api.query.S3Registry.S3Buckets.getValues(
+      bucketIds.map((s3BucketId) => [s3BucketId] as const),
+    );
+
     const buckets: BucketInfo[] = [];
-    for (const s3BucketId of bucketIds) {
-      const bucket = await api.query.S3Registry.S3Buckets.getValue(s3BucketId);
-      if (!bucket) continue;
+    const layer0BucketIds: bigint[] = [];
+    bucketValues.forEach((bucket, i) => {
+      if (!bucket) return;
       buckets.push({
-        s3BucketId,
+        s3BucketId: bucketIds[i]!,
         name: decodeName(bucket.name),
         layer0BucketId: bucket.layer0_bucket_id,
         owner: bucket.owner,
         createdAt: BigInt(bucket.created_at ?? 0),
+        providerInfo: [],
       });
-    }
+      layer0BucketIds.push(bucket.layer0_bucket_id);
+    });
+
+    // Resolve each bucket's primary providers, batching every storage read into
+    // a single query per pallet map (no per-bucket / per-provider round-trips).
+    // `layer0BucketInfo[i]` aligns with `buckets[i]` (both built skipping nulls).
+    const layer0BucketInfo = await api.query.StorageProvider.Buckets.getValues(
+      layer0BucketIds.map((id) => [id] as const),
+    );
+
+    const providerAccounts = [
+      ...new Set(layer0BucketInfo.flatMap((info) => info?.primary_providers ?? [])),
+    ];
+    const providerRecords = await api.query.StorageProvider.Providers.getValues(
+      providerAccounts.map((account) => [account] as const),
+    );
+
+    const providerMap = new Map<string, BucketProviderInfo>();
+    providerAccounts.forEach((account, i) => {
+      const record = providerRecords[i];
+      if (!record) return;
+      const multiaddr = new TextDecoder().decode(record.multiaddr);
+      providerMap.set(account, {
+        account,
+        multiaddr,
+        url: parseMultiaddrToUrl(multiaddr),
+      });
+    });
+
+    buckets.forEach((bucket, i) => {
+      bucket.providerInfo = (layer0BucketInfo[i]?.primary_providers ?? [])
+        .map((account) => providerMap.get(account))
+        .filter((info): info is BucketProviderInfo => info != null);
+    });
+
     return buckets;
   }
 

--- a/user-interfaces/s3-ui/src/state/s3.state.ts
+++ b/user-interfaces/s3-ui/src/state/s3.state.ts
@@ -352,7 +352,6 @@ export function dismissCreation(id: string): void {
 }
 
 interface RetryCtx {
-  name: string;
   provider: AvailableProvider;
   url: string;
   signed: SignedTerms;
@@ -366,7 +365,9 @@ export function canRetryCreation(id: string): boolean {
 async function runChainSubmit(id: string, ctx: RetryCtx): Promise<BucketInfo | null> {
   updateCreation(id, { stage: "submitting", error: undefined });
   try {
-    const bucket = await client.createBucket(ctx.name, ctx.provider.account, ctx.url, ctx.signed);
+    // Name lives on the creation record (keyed by id), not the retry context.
+    const name = creations$.getValue().find((c) => c.id === id)?.name ?? "";
+    const bucket = await client.createBucket(name, ctx.provider.account, ctx.url, ctx.signed);
     updateCreation(id, { stage: "ready", s3BucketId: bucket.s3BucketId });
     retryCtx.delete(id);
     await refreshBuckets();
@@ -393,7 +394,6 @@ export async function createBucket(input: CreateBucketInput): Promise<BucketInfo
   ]);
 
   const ctx: RetryCtx = {
-    name: input.name,
     provider: input.provider,
     url: input.url,
     signed: input.signed,
@@ -402,9 +402,15 @@ export async function createBucket(input: CreateBucketInput): Promise<BucketInfo
   return runChainSubmit(id, ctx);
 }
 
-export async function retryCreation(id: string): Promise<BucketInfo | null> {
+export async function retryCreation(
+  id: string,
+  name?: string,
+): Promise<BucketInfo | null> {
   const ctx = retryCtx.get(id);
   if (!ctx) return null;
+  // Let the caller override the name on retry (e.g. from the current input).
+  // runChainSubmit reads the name back off the creation record.
+  if (name !== undefined) updateCreation(id, { name });
   return runChainSubmit(id, ctx);
 }
 

--- a/user-interfaces/shared/network-picker/src/index.tsx
+++ b/user-interfaces/shared/network-picker/src/index.tsx
@@ -20,7 +20,7 @@ function healthUrl(base: string): string {
  * URLs). Returns the live { ws, http } statuses; re-runs whenever the resolved
  * URLs change.
  */
-function useEndpointProbes(ws: string, http: string) {
+function useEndpointProbes(ws: string, http?: string) {
   const [wsStatus, setWsStatus] = useState<Status>('idle')
   const [httpStatus, setHttpStatus] = useState<Status>('idle')
   const tokenRef = useRef(0)
@@ -163,6 +163,8 @@ export interface NetworkPickerProps {
   /** Render as a compact button that opens a popover. Default: inline panel. */
   compact?: boolean
   className?: string
+  /** Color scheme. Default: "light". */
+  theme?: "light" | "dark"
 }
 
 export function NetworkPicker(props: NetworkPickerProps) {
@@ -176,9 +178,10 @@ function InlinePicker({
   onSelect,
   onSelectCustom,
   className,
+  theme = 'light',
 }: NetworkPickerProps) {
   return (
-    <div className={`np-root ${className ?? ''}`} data-testid="network-picker">
+    <div className={`np-root ${className ?? ''}`} data-theme={theme} data-testid="network-picker">
       <PickerBody
         selectedNetwork={selectedNetwork}
         networkList={networkList}
@@ -195,17 +198,17 @@ function CompactPicker({
   onSelect,
   onSelectCustom,
   className,
+  theme = 'light',
 }: NetworkPickerProps) {
   const [open, setOpen] = useState(false)
   // Probes run for the button indicator regardless of popover state.
   const { wsStatus, httpStatus } = useEndpointProbes(
     selectedNetwork.parachainWs,
-    selectedNetwork.providerHttp,
   )
   const overall = combinedStatus(wsStatus, httpStatus)
 
   return (
-    <div className={`np-compact-root ${className ?? ''}`} data-testid="network-picker-compact">
+    <div className={`np-compact-root ${className ?? ''}`} data-theme={theme} data-testid="network-picker-compact">
       <button
         type="button"
         className="np-compact-button"
@@ -220,7 +223,7 @@ function CompactPicker({
       {open && (
         <>
           <div className="np-backdrop" onClick={() => setOpen(false)} />
-          <div className="np-popover np-root" data-testid="network-picker-popover">
+          <div className="np-popover np-root" data-theme={theme} data-testid="network-picker-popover">
             <PickerBody
               selectedNetwork={selectedNetwork}
               networkList={networkList}
@@ -246,10 +249,9 @@ function PickerBody({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const displayedWs = isCustom ? customWs.trim() : selectedNetwork.parachainWs
-  const displayedHttp = isCustom ? customHttp.trim() : selectedNetwork.providerHttp
   const placeholder = isCustom ? '(not set)' : 'Not deployed yet'
 
-  const { wsStatus, httpStatus } = useEndpointProbes(displayedWs, displayedHttp)
+  const { wsStatus } = useEndpointProbes(displayedWs)
 
   const hasCustomOption = useMemo(() => !networkList.some((n) => n.id === 'custom'), [networkList])
 
@@ -318,7 +320,6 @@ function PickerBody({
 
       <dl className="np-endpoints">
         <EndpointRow label="Parachain RPC" url={displayedWs} status={wsStatus} placeholder={placeholder} testidPrefix="network-picker-endpoint-ws" />
-        <EndpointRow label="Provider HTTP" url={displayedHttp} status={httpStatus} placeholder={placeholder} testidPrefix="network-picker-endpoint-http" />
       </dl>
     </>
   )

--- a/user-interfaces/shared/network-picker/src/styles.css
+++ b/user-interfaces/shared/network-picker/src/styles.css
@@ -1,3 +1,33 @@
+/*
+ * Theme palettes. Dark is the default (applied to the picker roots); a
+ * `data-theme="light"` on a root flips the variables for that subtree. Each
+ * `--np-*` still carries its dark value as a CSS fallback so the component
+ * renders correctly even if a consumer drops the stylesheet's variable block.
+ */
+.np-root,
+.np-compact-root {
+  --np-fg: #e5e5e5;
+  --np-bg: #1a1a2e;
+  --np-button-bg: #1f2937;
+  --np-input-bg: #0a0a0f;
+  --np-border: #2a2a3e;
+  --np-muted: #888;
+  --np-accent: #7c3aed;
+  --np-shadow: rgba(0, 0, 0, 0.5);
+}
+
+.np-root[data-theme='light'],
+.np-compact-root[data-theme='light'] {
+  --np-fg: #1a1a2e;
+  --np-bg: #ffffff;
+  --np-button-bg: #ffffff;
+  --np-input-bg: #f7f7fb;
+  --np-border: #d6d6e0;
+  --np-muted: #6b7280;
+  --np-accent: #7c3aed;
+  --np-shadow: rgba(15, 23, 42, 0.18);
+}
+
 .np-root {
   display: flex;
   flex-direction: column;
@@ -103,8 +133,8 @@
   display: flex;
   align-items: center;
   gap: 0.45rem;
-  background: var(--np-bg, #1f2937);
-  color: inherit;
+  background: var(--np-button-bg, #1f2937);
+  color: var(--np-fg, #e5e5e5);
   border: 1px solid var(--np-border, #2a2a3e);
   border-radius: 6px;
   padding: 0.32rem 0.65rem;
@@ -123,7 +153,7 @@
   top: calc(100% + 0.4rem);
   z-index: 50;
   width: 22rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 10px 30px var(--np-shadow, rgba(0, 0, 0, 0.5));
 }
 
 .np-endpoints-standalone { border-top: none; padding-top: 0; }

--- a/user-interfaces/shared/papi/package.json
+++ b/user-interfaces/shared/papi/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@multiformats/multiaddr-to-uri": "^12.0.0",
     "@polkadot-api/descriptors": "file:.papi/descriptors",
+    "@polkadot-api/utils": "^0.1.0",
     "@polkadot-labs/hdkd-helpers": "^0.0.30",
     "polkadot-api": "^2.1.6"
   }

--- a/user-interfaces/shared/papi/src/index.ts
+++ b/user-interfaces/shared/papi/src/index.ts
@@ -7,10 +7,18 @@
 import { ss58Address, ss58Decode } from '@polkadot-labs/hdkd-helpers'
 import { multiaddrToUri } from "@multiformats/multiaddr-to-uri";
 import { parachain } from "@polkadot-api/descriptors";
-import type { TypedApi } from "polkadot-api";
+import { Enum, type TypedApi } from "polkadot-api";
+import { fromHex, toHex } from "@polkadot-api/utils";
 
 /** Typed parachain API, shared by every UI that talks to the chain. */
 export type ParachainApi = TypedApi<typeof parachain>;
+
+/**
+ * Hex helpers re-exported from `@polkadot-api/utils` so UIs have one import
+ * site: `toHex` emits a `0x`-prefixed string, `fromHex` accepts hex with or
+ * without the prefix.
+ */
+export { fromHex, toHex };
 
 /**
  * SS58 address prefix used to encode public keys for display.
@@ -164,6 +172,95 @@ export async function negotiateProviderTerms(
       error: err instanceof Error ? err.message : "Failed to negotiate with provider",
     };
   }
+}
+
+const HTTP_RETRY_ATTEMPTS = 3;
+const HTTP_RETRY_BASE_MS = 250;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof DOMException &&
+    (err.name === "AbortError" || err.code === DOMException.ABORT_ERR)
+  );
+}
+
+function isRetryableHttpError(status: number | null): boolean {
+  if (status === null) return true;
+  return status >= 500 && status < 600;
+}
+
+/**
+ * `fetch` with bounded exponential-backoff retry on transient failures (5xx and
+ * network errors). Aborts (via `init.signal`) propagate immediately and are
+ * never retried.
+ */
+export async function httpFetch(
+  url: string,
+  init: RequestInit & { signal?: AbortSignal } = {},
+): Promise<Response> {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < HTTP_RETRY_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, init);
+      if (res.ok || !isRetryableHttpError(res.status)) return res;
+      lastError = new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
+    } catch (err) {
+      if (isAbortError(err)) throw err;
+      lastError = err;
+    }
+    if (attempt < HTTP_RETRY_ATTEMPTS - 1) {
+      await sleep(HTTP_RETRY_BASE_MS * Math.pow(2, attempt));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("HTTP request failed");
+}
+
+// SCALE variant ordering of sp_runtime::MultiSignature.
+const MULTI_SIGNATURE_VARIANT: Record<number, string> = {
+  0: "Ed25519",
+  1: "Sr25519",
+  2: "Ecdsa",
+  3: "Eth",
+};
+
+/**
+ * Build the `{ provider, terms, sig }` args shared by every signed-terms
+ * extrinsic.
+ *
+ * The inner of `MultiSignature::Sr25519` is `[u8; 64]`, which PAPI v2 encodes
+ * as `SizedBytes(64) = Codec<string>` — so the signature payload is passed as a
+ * `0x`-prefixed hex string (via `toHex`), not a `Uint8Array`.
+ */
+export function buildSignedTermsArgs(providerAccount: string, signed: SignedTerms) {
+  const sigBytes = fromHex(signed.signature);
+  if (sigBytes.length < 1) {
+    throw new Error("signature too short to contain a MultiSignature variant byte");
+  }
+  const variantByte = sigBytes[0]!;
+  const variantName = MULTI_SIGNATURE_VARIANT[variantByte];
+  if (!variantName) {
+    throw new Error(`unknown MultiSignature variant byte: ${variantByte}`);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sig = Enum(variantName as any, toHex(sigBytes.slice(1)));
+
+  const t = signed.terms;
+  const terms = {
+    owner: t.owner,
+    max_bytes: BigInt(t.max_bytes),
+    duration: t.duration,
+    price_per_byte: BigInt(t.price_per_byte),
+    valid_until: t.valid_until,
+    nonce: BigInt(t.nonce),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    replica_params: (t.replica_params ?? undefined) as any,
+    bucket_id: t.bucket_id ? BigInt(t.bucket_id) : undefined,
+  };
+  return { provider: providerAccount, terms, sig };
 }
 
 /**

--- a/user-interfaces/shared/papi/src/index.ts
+++ b/user-interfaces/shared/papi/src/index.ts
@@ -83,6 +83,90 @@ export function parseMultiaddrToUrl(multiaddr: string): string | null {
 }
 
 /**
+ * Provider-signed agreement terms returned by `POST /negotiate` on the
+ * provider node. The signature is the SCALE-encoded `MultiSignature` as
+ * hex (e.g. `0x01<64-byte-sr25519-sig>`).
+ */
+export interface SignedTerms {
+  terms: {
+    owner: string;
+    max_bytes: number | bigint;
+    duration: number;
+    price_per_byte: number | bigint;
+    valid_until: number;
+    nonce: number | bigint;
+    replica_params: unknown | null;
+    bucket_id: bigint | null;
+  };
+  signature: string;
+}
+
+/** Body of a `POST /negotiate` request to a provider node. */
+export interface NegotiateRequest {
+  owner: string;
+  max_bytes: number | bigint;
+  duration: number;
+  price_per_byte: number | bigint;
+  replica_params: unknown | null;
+  bucket_id?: bigint | null;
+}
+
+/**
+ * POST a `NegotiateRequest` to the provider's `/negotiate` endpoint and
+ * return the provider-signed terms bundle.
+ */
+export async function negotiateTerms(
+  providerUrl: string,
+  request: NegotiateRequest,
+): Promise<SignedTerms> {
+  const res = await fetch(`${providerUrl.replace(/\/$/, "")}/negotiate`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(request, (_k, v) => (typeof v === "bigint" ? v.toString() : v)),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`/negotiate failed: ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
+/** Outcome of {@link negotiateProviderTerms}: resolved endpoint + terms, or a UI-ready error. */
+export type NegotiateProviderResult =
+  | { ok: true; url: string; signed: SignedTerms }
+  | { ok: false; error: string };
+
+/**
+ * Resolve a provider's multiaddr to a base URL and negotiate signed terms in
+ * one step — the shared core of the "create bucket" / "create drive" flows.
+ *
+ * Returns a discriminated result instead of throwing so callers can surface the
+ * message inline: a `null` multiaddr and a failed `/negotiate` both come back as
+ * `{ ok: false, error }`.
+ */
+export async function negotiateProviderTerms(
+  provider: { account: string; multiaddr: string },
+  request: NegotiateRequest,
+): Promise<NegotiateProviderResult> {
+  const url = parseMultiaddrToUrl(provider.multiaddr);
+  if (!url) {
+    return {
+      ok: false,
+      error: `Provider ${provider.account} has an unparseable multiaddr: ${provider.multiaddr}`,
+    };
+  }
+  try {
+    const signed = await negotiateTerms(url, request);
+    return { ok: true, url, signed };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Failed to negotiate with provider",
+    };
+  }
+}
+
+/**
  * Resolve the HTTP(S) endpoint for a bucket's primary provider purely from
  * on-chain data: read the bucket, walk its primary providers, and return the
  * first one whose registered multiaddr parses to an HTTP(S) URL.

--- a/user-interfaces/shared/test-helpers/src/buckets.ts
+++ b/user-interfaces/shared/test-helpers/src/buckets.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { Binary, Enum } from "polkadot-api";
+import { Binary } from "polkadot-api";
+import { buildSignedTermsArgs, negotiateTerms } from "@web3-storage/papi";
 import { getApi, submitExtrinsic, submitExtrinsicBestBlock } from "./chain-api";
 import { Alice, type DevSigner } from "./signers";
 
@@ -8,105 +9,6 @@ import { Alice, type DevSigner } from "./signers";
 
 const DEFAULT_PROVIDER_URL = "http://127.0.0.1:3333";
 const DEFAULT_PROVIDER_ACCOUNT = Alice.address;
-
-// SCALE variant ordering of sp_runtime::MultiSignature.
-const MULTI_SIGNATURE_VARIANT: Record<number, string> = {
-  0: "Ed25519",
-  1: "Sr25519",
-  2: "Ecdsa",
-  3: "Eth",
-};
-
-interface NegotiateRequest {
-  owner: string;
-  max_bytes: number | bigint;
-  duration: number;
-  price_per_byte: number | bigint;
-  replica_params: unknown | null;
-  bucket_id: bigint | null;
-}
-
-interface SignedTerms {
-  terms: {
-    owner: string;
-    max_bytes: number | bigint;
-    duration: number;
-    price_per_byte: number | bigint;
-    valid_until: number;
-    nonce: number | bigint;
-    replica_params: unknown | null;
-    bucket_id: bigint | null;
-  };
-  signature: string;
-}
-
-async function negotiateTerms(
-  providerUrl: string,
-  request: NegotiateRequest,
-): Promise<SignedTerms> {
-  const res = await fetch(`${providerUrl.replace(/\/$/, "")}/negotiate`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(request, (_k, v) =>
-      typeof v === "bigint" ? v.toString() : v,
-    ),
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`/negotiate failed: ${res.status} ${body}`);
-  }
-  return res.json();
-}
-
-function hexToBytes(hex: string): Uint8Array {
-  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
-  const out = new Uint8Array(h.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16);
-  }
-  return out;
-}
-
-/**
- * Build the `{ provider, terms, sig }` args shared by every signed-terms
- * extrinsic. Mirrors `console-ui/src/lib/storage.ts::buildSignedTermsArgs`.
- *
- * The inner of `MultiSignature::Sr25519` is `[u8; 64]` which PAPI v2 encodes
- * as `SizedBytes(64) = Codec<string>` — pass a `0x`-prefixed hex string,
- * NOT a `Uint8Array`. (See PAPI v2 migration doc + console-ui's working
- * implementation.)
- */
-function buildSignedTermsArgs(providerAccount: string, signed: SignedTerms) {
-  const sigBytes = hexToBytes(signed.signature);
-  if (sigBytes.length < 1) {
-    throw new Error("signature too short to contain a MultiSignature variant byte");
-  }
-  const variantName = MULTI_SIGNATURE_VARIANT[sigBytes[0]];
-  if (!variantName) {
-    throw new Error(`unknown MultiSignature variant byte: ${sigBytes[0]}`);
-  }
-  const sigPayloadHex =
-    "0x" +
-    Array.from(sigBytes.slice(1))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sig = Enum(variantName as any, sigPayloadHex);
-
-  const t = signed.terms;
-  const terms = {
-    owner: t.owner,
-    max_bytes: BigInt(t.max_bytes),
-    duration: t.duration,
-    price_per_byte: BigInt(t.price_per_byte),
-    valid_until: t.valid_until,
-    nonce: BigInt(t.nonce),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    replica_params: (t.replica_params ?? undefined) as any,
-    bucket_id: t.bucket_id ?? undefined,
-  };
-  return { provider: providerAccount, terms, sig };
-}
 
 // ─── S3 Buckets (console-ui) ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Selecting a TLS-terminated provider in the S3 UI failed with a browser **Mixed Content** error:

> Mixed Content: The page at `https://paritytech.github.io/web3-storage/s3/` was loaded over HTTPS, but requested an insecure resource `http://previewnet.substrate.dev:443/negotiate`. This request has been blocked.

## Root cause

The bucket-creation / provider-selection path (`NewBucketDialog` → `negotiateTerms`) built the provider base URL with a **local** `parseMultiaddrToHttp` in `s3-ui/src/lib/s3-client.ts`. That parser only pulled out host + `tcp` port and **hardcoded `http://`**, ignoring the `/tls/` segment.

A provider registered on-chain as:

```
/dns4/previewnet.substrate.dev/tcp/443/tls/http/http-path/web3-storage-provider
```

was therefore turned into `http://previewnet.substrate.dev:443` — plain HTTP on port 443 — which the browser blocks on the HTTPS-served Pages site.

## Fix

Delegate to the shared `parseMultiaddrToUrl` from `@web3-storage/papi`, which speaks the full multiaddr grammar via `@multiformats/multiaddr-to-uri` (`tls` → `https`, `http-path`, default-port elision). This is the **same** parser `resolveProviderEndpoint` already uses for subsequent S3 operations, so the negotiate path and later operations now agree on the endpoint.

Resolved URLs:

| Multiaddr | Before | After |
|---|---|---|
| `/dns4/host/tcp/443/tls/http/http-path/web3-storage-provider` | `http://host:443` ❌ | `https://host/web3-storage-provider` ✅ |
| `/ip4/127.0.0.1/tcp/3333` (local dev) | `http://127.0.0.1:3333` | `http://127.0.0.1:3333` (unchanged) |

## Verification

- `tsc -b && vite build` passes for `@web3-storage/s3-ui`.
- Confirmed `previewnet.substrate.dev` is reachable over HTTPS: `POST https://previewnet.substrate.dev/web3-storage-provider/negotiate` returns a real provider response (422 on an empty body) with permissive CORS headers.
- Verified both providers on previewnet register the correct `…/tls/http/http-path/web3-storage-provider` multiaddr.

## Deploy

Merging into `dev` triggers `deploy-ui.yml`, which rebuilds and redeploys the UIs to GitHub Pages automatically.