### PR TITLE
Provider UI: fix challenge respond-all bug + auto-refresh & cache controls

### DIFF
--- a/user-interfaces/provider/src/App.tsx
+++ b/user-interfaces/provider/src/App.tsx
@@ -12,10 +12,12 @@ import { Challenges } from '@/pages/Challenges'
 import { Earnings } from '@/pages/Earnings'
 import { useSelectedAccount } from '@/state/wallet.state'
 import { loadProviderData, addChallengeFromEvent } from '@/state/provider.state'
+import { useAutoRefreshSecs } from '@/state/settings.state'
 import { subscribeToChallengeEvents } from '@/lib/chain-client'
 
 function App() {
   const selectedAccount = useSelectedAccount()
+  const autoRefreshSecs = useAutoRefreshSecs()
 
   // Load provider data at app level so all pages have it on initial render
   useEffect(() => {
@@ -23,6 +25,18 @@ function App() {
       loadProviderData(selectedAccount.address)
     }
   }, [selectedAccount?.address])
+
+  // Auto-refresh: periodically re-fetch provider data in the background. The
+  // refresh is silent (no loading/error flashes) and the interval is
+  // user-configurable from the header; `0` disables it.
+  useEffect(() => {
+    const address = selectedAccount?.address
+    if (!address || autoRefreshSecs <= 0) return
+    const id = setInterval(() => {
+      loadProviderData(address, { silent: true })
+    }, autoRefreshSecs * 1000)
+    return () => clearInterval(id)
+  }, [selectedAccount?.address, autoRefreshSecs])
 
   // Subscribe to challenge events in real-time so they're captured
   // while the block is still pinned (scanning old blocks doesn't work)

--- a/user-interfaces/provider/src/components/Header.tsx
+++ b/user-interfaces/provider/src/components/Header.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import {
   Server,
@@ -13,6 +13,8 @@ import {
   TestTube,
   Wallet,
   ArrowLeft,
+  RefreshCw,
+  Trash2,
 } from 'lucide-react'
 
 const LANDING_URL = import.meta.env.DEV ? 'http://127.0.0.1:5176/' : '../'
@@ -37,6 +39,13 @@ import {
   selectNetwork,
   selectCustomNetwork,
 } from '@/state/network.state'
+import { loadProviderData, clearLocalCache } from '@/state/provider.state'
+import {
+  useAutoRefreshSecs,
+  setAutoRefreshSecs,
+  AUTO_REFRESH_OPTIONS,
+  formatInterval,
+} from '@/state/settings.state'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Spinner } from '@/components/ui/Spinner'
@@ -63,10 +72,55 @@ export function Header() {
   const accounts = useAccounts()
   const selectedNetwork = useSelectedNetwork()
   const networkList = useNetworkList()
+  const autoRefreshSecs = useAutoRefreshSecs()
 
   const [showConnectOptions, setShowConnectOptions] = useState(false)
   const [showExtensionPicker, setShowExtensionPicker] = useState(false)
   const [showAccountPicker, setShowAccountPicker] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  // The cache-reset action is intentionally hidden: it only appears while Alt
+  // (Option) is held with the settings menu open, so it can't be hit by
+  // accident but is there when an operator needs it.
+  const [altHeld, setAltHeld] = useState(false)
+
+  useEffect(() => {
+    if (!showSettings) {
+      setAltHeld(false)
+      return
+    }
+    const sync = (e: KeyboardEvent) => setAltHeld(e.altKey)
+    window.addEventListener('keydown', sync)
+    window.addEventListener('keyup', sync)
+    return () => {
+      window.removeEventListener('keydown', sync)
+      window.removeEventListener('keyup', sync)
+    }
+  }, [showSettings])
+
+  const handleRefreshNow = async () => {
+    setShowSettings(false)
+    if (!selectedAccount?.address) return
+    setIsRefreshing(true)
+    try {
+      await loadProviderData(selectedAccount.address, { silent: true })
+    } finally {
+      setIsRefreshing(false)
+    }
+  }
+
+  const handleClearCache = async () => {
+    setShowSettings(false)
+    clearLocalCache()
+    if (selectedAccount?.address) {
+      setIsRefreshing(true)
+      try {
+        await loadProviderData(selectedAccount.address, { silent: true })
+      } finally {
+        setIsRefreshing(false)
+      }
+    }
+  }
 
   const handleConnectClick = async () => {
     // Connect to chain first if needed
@@ -135,6 +189,7 @@ export function Header() {
     setShowConnectOptions(false)
     setShowExtensionPicker(false)
     setShowAccountPicker(false)
+    setShowSettings(false)
   }
 
   return (
@@ -200,6 +255,73 @@ export function Header() {
               />
               {connectionStatus === 'connected' && blockNumber > 0 && (
                 <Badge variant="secondary" data-testid="block-number">#{blockNumber.toLocaleString()}</Badge>
+              )}
+            </div>
+
+            {/* Refresh & cache settings */}
+            <div className="relative">
+              <Button
+                data-testid="provider-settings-button"
+                variant="outline"
+                size="sm"
+                onClick={() => setShowSettings(!showSettings)}
+                title="Auto-refresh & cache"
+                className="flex items-center gap-1.5"
+              >
+                <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+                <span className="text-xs" data-testid="auto-refresh-current">
+                  {formatInterval(autoRefreshSecs)}
+                </span>
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+
+              {showSettings && (
+                <div className="absolute right-0 mt-2 w-64 bg-gray-800 border border-gray-700 rounded-lg shadow-xl overflow-hidden z-50">
+                  <div className="p-3 border-b border-gray-700">
+                    <div className="text-xs text-gray-400 mb-2">Auto-refresh interval</div>
+                    <div className="grid grid-cols-4 gap-1">
+                      {AUTO_REFRESH_OPTIONS.map((opt) => (
+                        <button
+                          key={opt}
+                          data-testid={`auto-refresh-${opt}`}
+                          onClick={() => setAutoRefreshSecs(opt)}
+                          className={`px-2 py-1 rounded text-xs font-medium transition-colors ${
+                            autoRefreshSecs === opt
+                              ? 'bg-purple-500/20 text-purple-400'
+                              : 'text-gray-400 hover:text-gray-100 hover:bg-gray-700'
+                          }`}
+                        >
+                          {formatInterval(opt)}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <button
+                    data-testid="provider-refresh-now"
+                    onClick={() => { void handleRefreshNow() }}
+                    disabled={!selectedAccount || isRefreshing}
+                    className="w-full text-left px-3 py-2 text-sm hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  >
+                    <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+                    Refresh now
+                  </button>
+
+                  {altHeld ? (
+                    <button
+                      data-testid="provider-clear-cache"
+                      onClick={() => { void handleClearCache() }}
+                      className="w-full text-left px-3 py-2 text-sm text-red-400 hover:bg-gray-700 border-t border-gray-700 flex items-center gap-2"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Clear cached history
+                    </button>
+                  ) : (
+                    <div className="px-3 py-2 text-[11px] text-gray-600 border-t border-gray-700 select-none">
+                      Hold Alt (⌥) to reveal cache reset
+                    </div>
+                  )}
+                </div>
               )}
             </div>
 
@@ -380,7 +502,7 @@ export function Header() {
       </div>
 
       {/* Click outside to close dropdowns */}
-      {(showConnectOptions || showExtensionPicker || showAccountPicker) && (
+      {(showConnectOptions || showExtensionPicker || showAccountPicker || showSettings) && (
         <div className="fixed inset-0 z-40" onClick={closeAllDropdowns} />
       )}
     </header>

--- a/user-interfaces/provider/src/components/Header.tsx
+++ b/user-interfaces/provider/src/components/Header.tsx
@@ -240,6 +240,8 @@ export function Header() {
               networkList={networkList}
               onSelect={(id) => { void selectNetwork(id); }}
               onSelectCustom={(input) => { void selectCustomNetwork(input); }}
+              theme='dark'
+              showProviderStatus
             />
 
             {/* Connection Status */}

--- a/user-interfaces/provider/src/pages/Challenges.tsx
+++ b/user-interfaces/provider/src/pages/Challenges.tsx
@@ -19,6 +19,7 @@ import {
   usePendingChallenges,
   respondToChallenge,
 } from '@/state/provider.state'
+import { challengeKey } from '@/state/challengeKey'
 import { useSelectedAccount } from '@/state/wallet.state'
 import { RequireProvider } from '@/components/RequireProvider'
 import { formatAddress, formatBlockNumber } from '@/utils/format'
@@ -35,28 +36,32 @@ function ChallengesContent() {
   const selectedAccount = useSelectedAccount()
   const challenges = useChallenges()
   const pendingChallenges = usePendingChallenges()
-  const [respondingTo, setRespondingTo] = useState<{ id: number; step: string } | null>(null)
-  const [respondError, setRespondError] = useState<{ id: number; message: string } | null>(null)
+  // Track the in-flight/errored challenge by its globally-unique key, not by
+  // `id` alone — `id` is the per-deadline index and collides across deadline
+  // blocks, which would light up every row sharing that index.
+  const [respondingTo, setRespondingTo] = useState<{ key: string; step: string } | null>(null)
+  const [respondError, setRespondError] = useState<{ key: string; message: string } | null>(null)
 
   const handleRespond = async (challenge: typeof challenges[number]) => {
     if (!selectedAccount) return
 
+    const key = challengeKey(challenge)
     setRespondError(null)
-    setRespondingTo({ id: challenge.id, step: 'Fetching proof...' })
+    setRespondingTo({ key, step: 'Fetching proof...' })
     try {
       await respondToChallenge(challenge, selectedAccount, (status) => {
         if (status.type === 'signing') {
-          setRespondingTo({ id: challenge.id, step: status.message.includes('Fetching') ? 'Fetching proof...' : 'Signing...' })
+          setRespondingTo({ key, step: status.message.includes('Fetching') ? 'Fetching proof...' : 'Signing...' })
         } else if (status.type === 'broadcast') {
-          setRespondingTo({ id: challenge.id, step: 'Broadcasting...' })
+          setRespondingTo({ key, step: 'Broadcasting...' })
         } else if (status.type === 'inBlock') {
-          setRespondingTo({ id: challenge.id, step: 'Confirming...' })
+          setRespondingTo({ key, step: 'Confirming...' })
         }
       })
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
       console.error('Failed to respond to challenge:', error)
-      setRespondError({ id: challenge.id, message: msg })
+      setRespondError({ key, message: msg })
     } finally {
       setRespondingTo(null)
     }
@@ -202,9 +207,11 @@ function ChallengesContent() {
                     if (a.status !== 'pending' && b.status === 'pending') return 1
                     return b.createdAt - a.createdAt
                   })
-                  .map((challenge) => (
+                  .map((challenge) => {
+                    const rowKey = challengeKey(challenge)
+                    return (
                     <TableRow
-                      key={challenge.id}
+                      key={rowKey}
                       className={
                         challenge.status === 'pending' ? 'bg-yellow-500/5' : undefined
                       }
@@ -253,7 +260,7 @@ function ChallengesContent() {
                               onClick={() => handleRespond(challenge)}
                               disabled={respondingTo !== null}
                             >
-                              {respondingTo?.id === challenge.id ? (
+                              {respondingTo?.key === rowKey ? (
                                 <>
                                   <Spinner size="sm" className="mr-2" />
                                   {respondingTo.step}
@@ -262,7 +269,7 @@ function ChallengesContent() {
                                 'Respond'
                               )}
                             </Button>
-                            {respondError?.id === challenge.id && respondingTo === null && (
+                            {respondError?.key === rowKey && respondingTo === null && (
                               <p className="text-xs text-red-400 max-w-[200px] truncate" title={respondError.message}>
                                 {respondError.message}
                               </p>
@@ -277,7 +284,8 @@ function ChallengesContent() {
                         ) : null}
                       </TableCell>
                     </TableRow>
-                  ))}
+                    )
+                  })}
               </TableBody>
             </Table>
           )}

--- a/user-interfaces/provider/src/state/challengeKey.test.ts
+++ b/user-interfaces/provider/src/state/challengeKey.test.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { describe, it, expect } from 'vitest'
+import { challengeKey } from './challengeKey'
+
+describe('challengeKey', () => {
+  it('distinguishes challenges that share an id but differ in deadline', () => {
+    // `id` is the per-deadline index, so two challenges at index 0 in different
+    // deadline blocks must not collapse to the same key — that collision is what
+    // made responding to one challenge light up every row sharing the index.
+    const a = challengeKey({ deadline: 100, id: 0 })
+    const b = challengeKey({ deadline: 200, id: 0 })
+    expect(a).not.toBe(b)
+  })
+
+  it('is stable for the same deadline + id', () => {
+    expect(challengeKey({ deadline: 100, id: 3 })).toBe(challengeKey({ deadline: 100, id: 3 }))
+  })
+
+  it('distinguishes different ids within the same deadline', () => {
+    expect(challengeKey({ deadline: 100, id: 0 })).not.toBe(challengeKey({ deadline: 100, id: 1 }))
+  })
+})

--- a/user-interfaces/provider/src/state/challengeKey.ts
+++ b/user-interfaces/provider/src/state/challengeKey.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+/**
+ * Stable, globally-unique identity for a challenge.
+ *
+ * On chain a challenge is addressed by `{ deadline, index }` and the UI's `id`
+ * holds the per-deadline `index`, so `id` alone collides across deadline blocks
+ * (e.g. two challenges both at index 0). Anything that identifies a single
+ * challenge — cache keys, React list keys, in-flight/error tracking — must key
+ * on this rather than on `id`.
+ *
+ * Kept in its own leaf module (no side-effecting imports) so it can be unit
+ * tested without pulling in the chain/state graph.
+ */
+export function challengeKey(c: { deadline: number; id: number }): string {
+  return `${c.deadline}-${c.id}`
+}

--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -27,6 +27,7 @@ import {
 import { isSameAddress } from '@web3-storage/papi'
 import { getCurrentBlock } from '@/state/chain.state'
 import { getProviderHttp } from '@/state/network.state'
+import { challengeKey } from '@/state/challengeKey'
 
 // Types (matching chain types with some UI additions)
 export interface ProviderInfo {
@@ -257,9 +258,9 @@ export async function loadProviderData(address: string): Promise<void> {
     const existing = challenges$.getValue()
     const merged = new Map<string, Challenge>()
     // Keep existing (may include responded/slashed from prior polls)
-    for (const c of existing) merged.set(`${c.deadline}-${c.id}`, c)
+    for (const c of existing) merged.set(challengeKey(c), c)
     // Overlay with fresh data (updates status for ones still visible)
-    for (const c of newChallenges) merged.set(`${c.deadline}-${c.id}`, c)
+    for (const c of newChallenges) merged.set(challengeKey(c), c)
     challenges$.next(Array.from(merged.values()).sort((a, b) => b.deadline - a.deadline))
 
     // Phase 2: Fetch bucket details (depends on agreement data for bucket IDs)
@@ -528,10 +529,10 @@ export async function respondToChallenge(
   )
 
   // Step 3: Update local state
-  const key = `${challenge.deadline}-${challenge.id}`
+  const key = challengeKey(challenge)
   const existing = challenges$.getValue()
   const merged = new Map<string, Challenge>()
-  for (const c of existing) merged.set(`${c.deadline}-${c.id}`, c)
+  for (const c of existing) merged.set(challengeKey(c), c)
   merged.set(key, { ...challenge, status: 'responded' })
   challenges$.next(Array.from(merged.values()).sort((a, b) => b.deadline - a.deadline))
 }
@@ -554,10 +555,10 @@ export function clearProviderState(): void {
  */
 export function addChallengeFromEvent(onChainChallenge: import('@/lib/chain-client').OnChainChallenge): void {
   const challenge = convertChallenge(onChainChallenge)
-  const key = `${challenge.deadline}-${challenge.id}`
+  const key = challengeKey(challenge)
   const existing = challenges$.getValue()
   const merged = new Map<string, Challenge>()
-  for (const c of existing) merged.set(`${c.deadline}-${c.id}`, c)
+  for (const c of existing) merged.set(challengeKey(c), c)
 
   const prev = merged.get(key)
   if (prev) {

--- a/user-interfaces/provider/src/state/provider.state.ts
+++ b/user-interfaces/provider/src/state/provider.state.ts
@@ -163,6 +163,22 @@ function clearStaleCache(genesisHash: string) {
   localStorage.setItem(CHALLENGES_GENESIS_KEY, genesisHash)
 }
 
+/**
+ * Clear locally-cached chain data — the persisted challenges cache and the
+ * in-memory list. Preferences (wallet, network, auto-refresh) are NOT touched;
+ * those live under different keys. Callers typically follow with
+ * `loadProviderData` to refetch fresh state from chain.
+ */
+export function clearLocalCache(): void {
+  challenges$.next([])
+  try {
+    localStorage.removeItem(CHALLENGES_STORAGE_KEY)
+    localStorage.removeItem(CHALLENGES_GENESIS_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
 // State subjects
 const providerInfo$ = new BehaviorSubject<ProviderInfo | null>(null)
 const providerSettings$ = new BehaviorSubject<ProviderSettings | null>(null)
@@ -219,9 +235,18 @@ export const [useProviderError] = bind(error$, null)
 /**
  * Load provider data from chain
  */
-export async function loadProviderData(address: string): Promise<void> {
-  isLoading$.next(true)
-  error$.next(null)
+export async function loadProviderData(
+  address: string,
+  opts: { silent?: boolean } = {},
+): Promise<void> {
+  // Silent refreshes (e.g. the auto-refresh timer) update data in place without
+  // toggling the global loading flag or surfacing transient errors, so the UI
+  // doesn't flash loading/error states on every tick.
+  const silent = opts.silent ?? false
+  if (!silent) {
+    isLoading$.next(true)
+    error$.next(null)
+  }
 
   try {
     // Clear stale challenge cache if chain restarted (different genesis)
@@ -323,9 +348,13 @@ export async function loadProviderData(address: string): Promise<void> {
       activeAgreementValue: activeValue,
     })
   } catch (err) {
-    error$.next(err instanceof Error ? err.message : 'Failed to load provider data')
+    if (silent) {
+      console.warn('Auto-refresh failed to load provider data:', err)
+    } else {
+      error$.next(err instanceof Error ? err.message : 'Failed to load provider data')
+    }
   } finally {
-    isLoading$.next(false)
+    if (!silent) isLoading$.next(false)
   }
 }
 
@@ -698,4 +727,5 @@ export const providerActions = {
   completeDeregister,
   respondToChallenge,
   clearProviderState,
+  clearLocalCache,
 }

--- a/user-interfaces/provider/src/state/settings.state.ts
+++ b/user-interfaces/provider/src/state/settings.state.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+/**
+ * UI settings that persist across reloads (preferences, not cached chain data).
+ *
+ * Currently holds the auto-refresh interval used to periodically re-fetch
+ * provider data. `0` means auto-refresh is off.
+ */
+
+import { BehaviorSubject } from 'rxjs'
+import { bind } from '@react-rxjs/core'
+
+const AUTO_REFRESH_KEY = 'provider-auto-refresh-secs'
+
+/** Selectable intervals in seconds; `0` is "Off". */
+export const AUTO_REFRESH_OPTIONS = [0, 15, 30, 60] as const
+export type AutoRefreshSecs = (typeof AUTO_REFRESH_OPTIONS)[number]
+
+/** Default: refresh every 30s. */
+export const DEFAULT_AUTO_REFRESH_SECS: AutoRefreshSecs = 30
+
+function isValidInterval(n: number): n is AutoRefreshSecs {
+  return (AUTO_REFRESH_OPTIONS as readonly number[]).includes(n)
+}
+
+function loadAutoRefreshSecs(): AutoRefreshSecs {
+  try {
+    const raw = localStorage.getItem(AUTO_REFRESH_KEY)
+    if (raw === null) return DEFAULT_AUTO_REFRESH_SECS
+    const n = Number(raw)
+    return isValidInterval(n) ? n : DEFAULT_AUTO_REFRESH_SECS
+  } catch {
+    return DEFAULT_AUTO_REFRESH_SECS
+  }
+}
+
+const autoRefreshSecs$ = new BehaviorSubject<AutoRefreshSecs>(loadAutoRefreshSecs())
+
+export const [useAutoRefreshSecs] = bind(autoRefreshSecs$, DEFAULT_AUTO_REFRESH_SECS)
+
+/** Update the auto-refresh interval and persist the choice. */
+export function setAutoRefreshSecs(secs: AutoRefreshSecs): void {
+  autoRefreshSecs$.next(secs)
+  try {
+    localStorage.setItem(AUTO_REFRESH_KEY, String(secs))
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Human-readable label for an interval. */
+export function formatInterval(secs: AutoRefreshSecs): string {
+  return secs === 0 ? 'Off' : `${secs}s`
+}

--- a/user-interfaces/shared/network-picker/src/index.tsx
+++ b/user-interfaces/shared/network-picker/src/index.tsx
@@ -20,7 +20,7 @@ function healthUrl(base: string): string {
  * URLs). Returns the live { ws, http } statuses; re-runs whenever the resolved
  * URLs change.
  */
-function useEndpointProbes(ws: string, http?: string) {
+function useEndpointProbes(ws: string, http: string) {
   const [wsStatus, setWsStatus] = useState<Status>('idle')
   const [httpStatus, setHttpStatus] = useState<Status>('idle')
   const tokenRef = useRef(0)
@@ -165,6 +165,8 @@ export interface NetworkPickerProps {
   className?: string
   /** Color scheme. Default: "light". */
   theme?: "light" | "dark"
+  // show provider status
+  showProviderStatus?: boolean
 }
 
 export function NetworkPicker(props: NetworkPickerProps) {
@@ -179,6 +181,7 @@ function InlinePicker({
   onSelectCustom,
   className,
   theme = 'light',
+  showProviderStatus = false,
 }: NetworkPickerProps) {
   return (
     <div className={`np-root ${className ?? ''}`} data-theme={theme} data-testid="network-picker">
@@ -187,6 +190,7 @@ function InlinePicker({
         networkList={networkList}
         onSelect={onSelect}
         onSelectCustom={onSelectCustom}
+        showProviderStatus={showProviderStatus}
       />
     </div>
   )
@@ -199,11 +203,13 @@ function CompactPicker({
   onSelectCustom,
   className,
   theme = 'light',
+  showProviderStatus = false
 }: NetworkPickerProps) {
   const [open, setOpen] = useState(false)
   // Probes run for the button indicator regardless of popover state.
   const { wsStatus, httpStatus } = useEndpointProbes(
     selectedNetwork.parachainWs,
+    selectedNetwork.providerHttp,
   )
   const overall = combinedStatus(wsStatus, httpStatus)
 
@@ -229,6 +235,7 @@ function CompactPicker({
               networkList={networkList}
               onSelect={(id) => { void onSelect(id) }}
               onSelectCustom={(input) => { void onSelectCustom(input) }}
+              showProviderStatus={showProviderStatus}
             />
           </div>
         </>
@@ -242,16 +249,18 @@ function PickerBody({
   networkList,
   onSelect,
   onSelectCustom,
-}: Pick<NetworkPickerProps, 'selectedNetwork' | 'networkList' | 'onSelect' | 'onSelectCustom'>) {
+  showProviderStatus,
+}: Pick<NetworkPickerProps, 'selectedNetwork' | 'networkList' | 'onSelect' | 'onSelectCustom' | 'showProviderStatus'>) {
   const isCustom = selectedNetwork.id === 'custom'
   const [customWs, setCustomWs] = useState(isCustom ? selectedNetwork.parachainWs : '')
   const [customHttp, setCustomHttp] = useState(isCustom ? selectedNetwork.providerHttp : '')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const displayedWs = isCustom ? customWs.trim() : selectedNetwork.parachainWs
+  const displayedHttp = isCustom ? customHttp.trim() : selectedNetwork.providerHttp
   const placeholder = isCustom ? '(not set)' : 'Not deployed yet'
 
-  const { wsStatus } = useEndpointProbes(displayedWs)
+  const { wsStatus, httpStatus } = useEndpointProbes(displayedWs, displayedHttp)
 
   const hasCustomOption = useMemo(() => !networkList.some((n) => n.id === 'custom'), [networkList])
 
@@ -320,6 +329,11 @@ function PickerBody({
 
       <dl className="np-endpoints">
         <EndpointRow label="Parachain RPC" url={displayedWs} status={wsStatus} placeholder={placeholder} testidPrefix="network-picker-endpoint-ws" />
+        {
+          showProviderStatus ? (
+            <EndpointRow label="Provider HTTP" url={displayedHttp} status={httpStatus} placeholder={placeholder} testidPrefix="network-picker-endpoint-http" />
+          ) : (<></>)
+        }
       </dl>
     </>
   )


### PR DESCRIPTION
Three provider-UI changes, grouped since they all touch the challenge/refresh flow.

## 1. Fix: clicking "Respond" lit up every matching challenge row

A challenge's on-chain identity is `{ deadline, index }`, and the UI's `challenge.id` holds the per-deadline **index** — which restarts each deadline block, so two pending challenges routinely share an `id` (e.g. both index `0`).

`Challenges.tsx` keyed its React rows, the in-flight `respondingTo` state, and the per-row error on `challenge.id` alone, so clicking **Respond** on one challenge activated the spinner/state on every row sharing that index (plus produced duplicate React keys).

Fix: a shared `challengeKey({ deadline, id })` helper (in its own side-effect-free leaf module so it's unit-testable) keys the React list, in-flight tracking, and error tracking. The state layer's existing `${deadline}-${id}` caches now route through the same helper so identity is defined in one place. Adds a regression test for the collision.

## 2. Feature: auto-refresh

- New `settings.state` holds a persisted interval (Off / 15s / 30s / 60s), default **30s**, selectable from a compact header dropdown next to the connection status.
- App-level timer re-fetches provider data on that interval. The refresh is **silent** — `loadProviderData` gained a `{ silent }` option that skips the global loading flag and error banner — so the UI doesn't flash loading/error state every tick.

## 3. Feature: cache handling + hidden reset

- The persisted challenges cache now **persists across restarts** and is only dropped when the chain changes (the existing `clearStaleCache` clears it on a genesis-hash change). Pending challenges are always re-fetched live; the cache preserves resolved-challenge history, which on-chain state no longer holds (it lives only in events — resolved/expired challenges are removed from `Challenges` storage).
- `clearLocalCache()` drops that cache and resets it in memory; wallet, network, and the auto-refresh setting live under other keys and are preserved.
- Exposed as a **hidden** "Clear cached history" action in the settings dropdown: it only appears while **Alt (⌥)** is held, so it can't be hit by accident but is there when an operator needs it.

## Verification
- `tsc -b` clean; production build succeeds; all 21 unit tests pass (incl. 3 new `challengeKey` tests).
- ESLint not run — it fails on a clean tree too (ESLint 10, no flat config present); pre-existing, unrelated.
- Not yet eyeballed in a live browser; happy to if preferred.