### PR TITLE
Security hardening

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -195,7 +195,8 @@ jobs:
           nohup ./target/release/storage-provider-node \
             --keyfile /tmp/alice-key --storage-mode inmemory \
             --bind-addr 0.0.0.0:3333 --chain-rpc ws://127.0.0.1:2222 \
-            --enable-checkpoint-coordinator > /tmp/provider-inmemory.log 2>&1 &
+            --enable-checkpoint-coordinator \
+            --disable-auth-i-know-what-i-am-doing > /tmp/provider-inmemory.log 2>&1 &
 
       - name: Wait for provider health
         uses: ./.github/actions/wait-for-provider-health
@@ -335,7 +336,8 @@ jobs:
             --keyfile /tmp/alice-key --storage-mode inmemory \
             --bind-addr 0.0.0.0:3333 --chain-rpc ws://127.0.0.1:2222 \
             --reconcile-interval-secs 1 \
-            --enable-checkpoint-coordinator > /tmp/provider.log 2>&1 &
+            --enable-checkpoint-coordinator \
+            --disable-auth-i-know-what-i-am-doing > /tmp/provider.log 2>&1 &
 
       - name: Wait for provider health
         uses: ./.github/actions/wait-for-provider-health
@@ -532,7 +534,8 @@ jobs:
           nohup ./target/release/storage-provider-node \
             --keyfile /tmp/alice-key --storage-mode inmemory \
             --bind-addr 0.0.0.0:3333 --chain-rpc ws://127.0.0.1:2222 \
-            --enable-checkpoint-coordinator > /tmp/provider.log 2>&1 &
+            --enable-checkpoint-coordinator \
+            --disable-auth-i-know-what-i-am-doing > /tmp/provider.log 2>&1 &
 
       - name: Wait for provider health
         uses: ./.github/actions/wait-for-provider-health
@@ -689,7 +692,8 @@ jobs:
           nohup ./target/release/storage-provider-node \
             --keyfile /tmp/alice-key --storage-mode inmemory \
             --bind-addr 0.0.0.0:3333 --chain-rpc ws://127.0.0.1:2222 \
-            --enable-checkpoint-coordinator > /tmp/provider.log 2>&1 &
+            --enable-checkpoint-coordinator \
+            --disable-auth-i-know-what-i-am-doing > /tmp/provider.log 2>&1 &
 
       - name: Wait for provider health
         uses: ./.github/actions/wait-for-provider-health

--- a/client/tests/common/mod.rs
+++ b/client/tests/common/mod.rs
@@ -240,8 +240,11 @@ pub async fn dev_discovery() -> Option<DiscoveryClient> {
 /// (`/commit`, `/commitment`, `/checkpoint/sign`, `/delete`) work end-to-end.
 pub async fn start_test_provider() -> String {
     let storage = Arc::new(Storage::new());
-    let state =
-        Arc::new(ProviderState::with_seed(storage, "//Alice").expect("//Alice is a valid SURI"));
+    let state = Arc::new(
+        ProviderState::with_seed(storage, "//Alice")
+            .expect("//Alice is a valid SURI")
+            .with_auth_disabled(),
+    );
     let app = create_router(state);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/docs/design/scalable-web3-storage-implementation.md
+++ b/docs/design/scalable-web3-storage-implementation.md
@@ -1720,8 +1720,10 @@ Rules:
   `Writer` for uploads/commits, `Admin` for delete and other destructive ops.
 - The membership cache uses stale-while-revalidate: if the chain is briefly
   unreachable, cached membership keeps working.
-- When the provider node is launched without auth (`--auth-disabled`), all
-  endpoints are permissive — useful for local demos, never in production.
+- Authentication is enforced by default. The only way to turn it off is the
+  deliberately verbose `--disable-auth-i-know-what-i-am-doing` flag, which makes
+  every endpoint publicly readable and writable. It exists for throwaway local
+  experiments only and must never be used for a real provider.
 
 ### Content-Addressed Storage
 
@@ -1918,7 +1920,7 @@ Delete Data (admin only)
 POST /delete
 Authorization: Web3Storage <pubkey_hex>:<signature_hex>:<timestamp>
   // admin-signed header (same scheme as other mutating endpoints);
-  // when auth is enabled the signer must be an Admin member of the bucket
+  // the signer must be an Admin member of the bucket
 
 Request:
 {

--- a/docs/design/scalable-web3-storage-implementation.md
+++ b/docs/design/scalable-web3-storage-implementation.md
@@ -1916,12 +1916,14 @@ Response (404 Not Found):
 Delete Data (admin only)
 ────────────────────────
 POST /delete
+Authorization: Web3Storage <pubkey_hex>:<signature_hex>:<timestamp>
+  // admin-signed header (same scheme as other mutating endpoints);
+  // when auth is enabled the signer must be an Admin member of the bucket
 
 Request:
 {
   "bucket_id": "0x1234...",
-  "new_start_seq": 10,
-  "admin_signature": "0x..."  // signs {bucket_id, new_start_seq}
+  "new_start_seq": 10
 }
 
 Response (200 OK):

--- a/justfile
+++ b/justfile
@@ -177,10 +177,10 @@ start-e2e-chain RUNTIME="web3-storage-paseo": check
 
 # Start the storage provider node (without registering on-chain)
 # Examples:
-#   just start-provider                                       # inmemory, //Alice key, port 3333
+#   just start-provider                                       # inmemory, //Alice key, port 3333, auth enforced
 #   just start-provider MODE=disk PORT=3334                    # disk storage on port 3334
 #   just start-provider KEYFILE=/path/to/seed MODE=disk        # custom key from file
-start-provider MODE="inmemory" PORT=PROVIDER_PORT STORAGE_PATH="./provider-data" KEYFILE="": build-provider
+start-provider MODE="inmemory" PORT=PROVIDER_PORT STORAGE_PATH="./provider-data" KEYFILE="" DISABLE_AUTH="false": build-provider
     #!/usr/bin/env bash
     set -euo pipefail
     echo ""
@@ -191,6 +191,9 @@ start-provider MODE="inmemory" PORT=PROVIDER_PORT STORAGE_PATH="./provider-data"
     EXTRA_ARGS=""
     if [ "{{MODE}}" = "disk" ]; then
         EXTRA_ARGS="--storage-path {{STORAGE_PATH}}"
+    fi
+    if [ "{{DISABLE_AUTH}}" = "true" ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --disable-auth-i-know-what-i-am-doing"
     fi
     if [ -n "{{KEYFILE}}" ]; then
         KEY_ARGS="--keyfile {{KEYFILE}}"

--- a/provider-node/README.md
+++ b/provider-node/README.md
@@ -14,7 +14,11 @@ just health           # check provider is up
 
 ## Authentication
 
-Mutating and bucket-scoped endpoints require a signed `Authorization` header.
+Authentication is enforced by default. Mutating and bucket-scoped endpoints
+require a signed `Authorization` header; the only way to turn enforcement off is
+the `--disable-auth-i-know-what-i-am-doing` flag, which opens every endpoint to
+the public and is meant strictly for throwaway local experiments.
+
 The client signs an sr25519 message binding the request to a bucket and a
 timestamp:
 

--- a/provider-node/README.md
+++ b/provider-node/README.md
@@ -12,6 +12,31 @@ just start-provider   # requires a running chain (just start-chain)
 just health           # check provider is up
 ```
 
+## Authentication
+
+Mutating and bucket-scoped endpoints require a signed `Authorization` header.
+The client signs an sr25519 message binding the request to a bucket and a
+timestamp:
+
+```text
+signed message:  web3storage:<METHOD>:<bucket_id>:<timestamp>
+header:          Authorization: Web3Storage <pubkey_hex>:<signature_hex>:<timestamp>
+```
+
+| Field          | Meaning                                                                 |
+| -------------- | ----------------------------------------------------------------------- |
+| `METHOD`       | Upper-case HTTP verb of the request (`GET`, `PUT`, `POST`, `DELETE`).   |
+| `bucket_id`    | Decimal id of the bucket the request targets.                           |
+| `timestamp`    | Client Unix time in **seconds**; identical in the message and header.   |
+| `pubkey_hex`   | 32-byte sr25519 public key, hex (optional `0x` prefix).                 |
+| `signature_hex`| 64-byte signature over the message, hex (optional `0x` prefix).         |
+
+The recovered public key is mapped to the bucket's on-chain role
+(`Reader` / `Writer` / `Admin`); reads need `Reader`, writes and deletes need
+`Writer`, and pruning (`POST /delete`) needs `Admin`. The `timestamp` must be
+within the configured skew window of the provider's clock or the request is
+rejected as expired.
+
 ## Test
 
 ```bash

--- a/provider-node/src/api.rs
+++ b/provider-node/src/api.rs
@@ -263,8 +263,18 @@ async fn get_node(
 
 async fn upload_node(
     State(state): State<Arc<ProviderState>>,
+    headers: axum::http::HeaderMap,
     Json(request): Json<UploadNodeRequest>,
 ) -> Result<Json<UploadNodeResponse>, Error> {
+    check_role(
+        &state,
+        &headers,
+        "PUT",
+        request.bucket_id,
+        RequiredRole::Writer,
+    )
+    .await?;
+
     // Decode hash
     let hash_bytes = hex_decode(&request.hash).map_err(|_| Error::InvalidHash {
         expected: request.hash.clone(),
@@ -340,8 +350,18 @@ async fn check_exists(
 
 async fn commit(
     State(state): State<Arc<ProviderState>>,
+    headers: axum::http::HeaderMap,
     Json(request): Json<CommitRequest>,
 ) -> Result<Json<CommitResponse>, Error> {
+    check_role(
+        &state,
+        &headers,
+        "POST",
+        request.bucket_id,
+        RequiredRole::Writer,
+    )
+    .await?;
+
     let data_roots: Vec<H256> = request
         .data_roots
         .iter()
@@ -545,8 +565,11 @@ async fn delete_data(
     headers: axum::http::HeaderMap,
     Json(request): Json<DeleteRequest>,
 ) -> Result<Json<DeleteResponse>, Error> {
-    // Pruning bucket data is destructive and admin-only: require an Admin-signed
-    // request, same as every other mutating endpoint.
+    // Admin-only, unlike the Writer-level deletes in the S3/FS layers: this L0
+    // prune rewrites the underlying MMR (dropping every leaf below
+    // `new_start_seq`), whereas the L1 deletes only drop an index entry and
+    // leave the tree intact. Rewriting the commitment is strictly more
+    // destructive, so it warrants the highest role.
     check_role(
         &state,
         &headers,

--- a/provider-node/src/api.rs
+++ b/provider-node/src/api.rs
@@ -519,10 +519,19 @@ async fn list_buckets(State(state): State<Arc<ProviderState>>) -> Json<ListBucke
 
 async fn delete_data(
     State(state): State<Arc<ProviderState>>,
+    headers: axum::http::HeaderMap,
     Json(request): Json<DeleteRequest>,
 ) -> Result<Json<DeleteResponse>, Error> {
-    // Note: In production, would verify admin_signature
-    let _ = request.admin_signature;
+    // Pruning bucket data is destructive and admin-only: require an Admin-signed
+    // request, same as every other mutating endpoint.
+    check_role(
+        &state,
+        &headers,
+        "POST",
+        request.bucket_id,
+        RequiredRole::Admin,
+    )
+    .await?;
 
     let (mmr_root, start_seq, leaf_count) = state
         .storage

--- a/provider-node/src/api.rs
+++ b/provider-node/src/api.rs
@@ -55,8 +55,18 @@ pub fn create_router(state: Arc<ProviderState>) -> Router {
                 origins.iter().filter_map(|o| o.parse().ok()).collect();
             CorsLayer::new()
                 .allow_origin(allowed)
-                .allow_methods(tower_http::cors::Any)
-                .allow_headers(tower_http::cors::Any)
+                // Only the verbs and request headers the API actually serves.
+                .allow_methods([
+                    axum::http::Method::GET,
+                    axum::http::Method::PUT,
+                    axum::http::Method::POST,
+                    axum::http::Method::DELETE,
+                    axum::http::Method::HEAD,
+                ])
+                .allow_headers([
+                    axum::http::header::AUTHORIZATION,
+                    axum::http::header::CONTENT_TYPE,
+                ])
         }
         _ => CorsLayer::permissive(),
     };

--- a/provider-node/src/api.rs
+++ b/provider-node/src/api.rs
@@ -48,6 +48,19 @@ pub fn create_router(state: Arc<ProviderState>) -> Router {
             .expect("static `/negotiate` rate-limit config is valid"),
     );
 
+    // Restrict CORS to the configured origins, or stay permissive when unset.
+    let cors = match &state.cors_allowed_origins {
+        Some(origins) if !origins.is_empty() => {
+            let allowed: Vec<axum::http::HeaderValue> =
+                origins.iter().filter_map(|o| o.parse().ok()).collect();
+            CorsLayer::new()
+                .allow_origin(allowed)
+                .allow_methods(tower_http::cors::Any)
+                .allow_headers(tower_http::cors::Any)
+        }
+        _ => CorsLayer::permissive(),
+    };
+
     Router::new()
         // Health and info
         .route("/health", get(health))
@@ -108,7 +121,7 @@ pub fn create_router(state: Arc<ProviderState>) -> Router {
         .route("/fs/:bucket_id/index_root", get(fs_api::fs_index_root))
         .layer(DefaultBodyLimit::max(256 * 1024 * 1024)) // 256 MB
         .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive())
+        .layer(cors)
         .with_state(state)
 }
 

--- a/provider-node/src/auth.rs
+++ b/provider-node/src/auth.rs
@@ -238,10 +238,32 @@ fn extract_role<T>(val: &subxt::ext::scale_value::Value<T>) -> Role {
     }
 }
 
-/// Verify an sr25519 signature from an Authorization header.
+/// Verify an sr25519 signature from an `Authorization` header.
 ///
-/// Header format: `Web3Storage <pubkey_hex>:<signature_hex>:<timestamp>`
-/// Signed message: `web3storage:<METHOD>:<bucket_id>:<timestamp>`
+/// The client signs the request by building the message
+///
+/// ```text
+/// web3storage:<METHOD>:<bucket_id>:<timestamp>
+/// ```
+///
+/// and sending the signature back in the `Authorization` header
+///
+/// ```text
+/// Authorization: Web3Storage <pubkey_hex>:<signature_hex>:<timestamp>
+/// ```
+///
+/// where:
+/// - `METHOD` is the upper-case HTTP verb of the request (`GET`, `PUT`, …).
+/// - `bucket_id` is the decimal bucket id the request targets.
+/// - `timestamp` is the client's current Unix time in **seconds**; the same
+///   string is used in both the signed message and the header. It must be
+///   within `max_skew` of the server clock or the request is rejected with
+///   [`Error::TimestampExpired`].
+/// - `pubkey_hex` / `signature_hex` are hex (optionally `0x`-prefixed) encodings
+///   of the 32-byte sr25519 public key and 64-byte signature.
+///
+/// On success returns the [`AccountId32`] derived from the recovered public key;
+/// the caller maps that account to a bucket role in [`require_role`].
 pub fn verify_signature(
     auth_header: &str,
     method: &str,

--- a/provider-node/src/auth.rs
+++ b/provider-node/src/auth.rs
@@ -330,7 +330,9 @@ pub fn verify_signature(
 
 /// Check that the caller has sufficient permissions.
 ///
-/// If auth is disabled, this is a no-op (returns Ok).
+/// Auth is enforced by default. This is a no-op (returns `Ok`) only when the
+/// operator started the node with `--disable-auth-i-know-what-i-am-doing`, which
+/// strips the membership config from the state.
 pub async fn require_role(
     state: &ProviderState,
     auth_header: Option<&str>,

--- a/provider-node/src/cli.rs
+++ b/provider-node/src/cli.rs
@@ -188,12 +188,17 @@ pub struct CheckpointParams {
 }
 
 /// Parameters for authentication and authorization.
+///
+/// Authentication and role-based access control are enforced by default. The
+/// only way to turn them off is the deliberately verbose
+/// `--disable-auth-i-know-what-i-am-doing` flag below.
 #[derive(Debug, clap::Args)]
 pub struct AuthParams {
-    /// Enable authentication and role-based access control.
-    /// When disabled (default), all requests are allowed without auth headers.
-    #[arg(long, env = "ENABLE_AUTH")]
-    pub enable_auth: bool,
+    /// Disable ALL authentication and role-based access control. Every endpoint
+    /// becomes publicly readable AND writable by anyone. Intended only for
+    /// throwaway local experiments — never run a real provider this way.
+    #[arg(long)]
+    pub disable_auth_i_know_what_i_am_doing: bool,
 
     /// Cache TTL in seconds for membership lookups from the chain.
     #[arg(

--- a/provider-node/src/cli.rs
+++ b/provider-node/src/cli.rs
@@ -95,6 +95,17 @@ pub struct RpcParams {
     /// `/dns4/example.com/tcp/443/tls/http/http-path/web3-storage-provider`.
     #[arg(long, value_name = "MULTIADDR", env = "PUBLIC_MULTIADDR")]
     pub public_multiaddr: Option<String>,
+
+    /// Comma-separated list of browser origins allowed via CORS
+    /// (e.g. "https://app.example.com,http://localhost:5174").
+    /// When unset, all origins are allowed (permissive) — set this in production.
+    #[arg(
+        long,
+        value_name = "ORIGIN",
+        env = "CORS_ALLOWED_ORIGINS",
+        value_delimiter = ','
+    )]
+    pub cors_allowed_origins: Option<Vec<String>>,
 }
 
 /// Parameters for provider identity and signing keys.

--- a/provider-node/src/command.rs
+++ b/provider-node/src/command.rs
@@ -50,6 +50,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let state = match &seed {
         Some(seed) => {
             let mut state = ProviderState::with_seed(storage, seed)?;
+            state.cors_allowed_origins = cli.rpc.cors_allowed_origins.clone();
             tracing::info!("Signing enabled for account: {}", state.provider_id);
 
             // Wire up auth if enabled
@@ -81,6 +82,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             let mut state = ProviderState::new(storage, provider_id);
+            state.cors_allowed_origins = cli.rpc.cors_allowed_origins.clone();
 
             if cli.auth.enable_auth {
                 let resolver = ChainMembershipResolver::new(cli.rpc.chain_rpc.clone());

--- a/provider-node/src/command.rs
+++ b/provider-node/src/command.rs
@@ -135,16 +135,27 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Apply CLI-derived CORS and auth settings to a freshly constructed state.
+///
+/// Authentication is enforced by default: unless the operator explicitly passed
+/// `--disable-auth-i-know-what-i-am-doing`, we wire in the on-chain membership
+/// resolver so every bucket-scoped request is checked against the caller's role.
 fn configure_state(state: ProviderState, cli: &Cli) -> ProviderState {
     let mut state = state.with_cors_origins(cli.rpc.cors_allowed_origins.clone());
 
-    if cli.auth.enable_auth {
+    if cli.auth.disable_auth_i_know_what_i_am_doing {
+        state = state.with_auth_disabled();
+        tracing::warn!(
+            "AUTHENTICATION DISABLED via --disable-auth-i-know-what-i-am-doing: \
+             every endpoint is publicly readable and writable by anyone. \
+             Never do this outside a throwaway local environment."
+        );
+    } else {
         let resolver = ChainMembershipResolver::new(cli.rpc.chain_rpc.clone());
         let ttl = Duration::from_secs(cli.auth.auth_cache_ttl);
         let cache = MembershipCache::new(Box::new(resolver), ttl);
         state.set_auth_config(Arc::new(cache), Duration::from_secs(cli.auth.auth_max_skew));
         tracing::info!(
-            "Auth enabled (cache_ttl={}s, max_skew={}s)",
+            "Auth enforced (cache_ttl={}s, max_skew={}s)",
             cli.auth.auth_cache_ttl,
             cli.auth.auth_max_skew
         );

--- a/provider-node/src/command.rs
+++ b/provider-node/src/command.rs
@@ -49,26 +49,9 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let seed = cli.key.load_seed()?;
     let state = match &seed {
         Some(seed) => {
-            let mut state = ProviderState::with_seed(storage, seed)?;
-            state.cors_allowed_origins = cli.rpc.cors_allowed_origins.clone();
+            let state = ProviderState::with_seed(storage, seed)?;
             tracing::info!("Signing enabled for account: {}", state.provider_id);
-
-            // Wire up auth if enabled
-            if cli.auth.enable_auth {
-                let resolver = ChainMembershipResolver::new(cli.rpc.chain_rpc.clone());
-                let ttl = Duration::from_secs(cli.auth.auth_cache_ttl);
-                let cache = MembershipCache::new(Box::new(resolver), ttl);
-                state.auth_enabled = true;
-                state.membership_cache = Some(Arc::new(cache));
-                state.auth_max_skew = Duration::from_secs(cli.auth.auth_max_skew);
-                tracing::info!(
-                    "Auth enabled (cache_ttl={}s, max_skew={}s)",
-                    cli.auth.auth_cache_ttl,
-                    cli.auth.auth_max_skew
-                );
-            }
-
-            Arc::new(state)
+            Arc::new(configure_state(state, &cli))
         }
         None => {
             let provider_id = cli
@@ -81,24 +64,10 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 provider_id
             );
 
-            let mut state = ProviderState::new(storage, provider_id);
-            state.cors_allowed_origins = cli.rpc.cors_allowed_origins.clone();
-
-            if cli.auth.enable_auth {
-                let resolver = ChainMembershipResolver::new(cli.rpc.chain_rpc.clone());
-                let ttl = Duration::from_secs(cli.auth.auth_cache_ttl);
-                let cache = MembershipCache::new(Box::new(resolver), ttl);
-                state.auth_enabled = true;
-                state.membership_cache = Some(Arc::new(cache));
-                state.auth_max_skew = Duration::from_secs(cli.auth.auth_max_skew);
-                tracing::info!(
-                    "Auth enabled (cache_ttl={}s, max_skew={}s)",
-                    cli.auth.auth_cache_ttl,
-                    cli.auth.auth_max_skew
-                );
-            }
-
-            Arc::new(state)
+            Arc::new(configure_state(
+                ProviderState::with_provider_id(storage, provider_id),
+                &cli,
+            ))
         }
     };
 
@@ -163,6 +132,25 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     Ok(())
+}
+
+/// Apply CLI-derived CORS and auth settings to a freshly constructed state.
+fn configure_state(state: ProviderState, cli: &Cli) -> ProviderState {
+    let mut state = state.with_cors_origins(cli.rpc.cors_allowed_origins.clone());
+
+    if cli.auth.enable_auth {
+        let resolver = ChainMembershipResolver::new(cli.rpc.chain_rpc.clone());
+        let ttl = Duration::from_secs(cli.auth.auth_cache_ttl);
+        let cache = MembershipCache::new(Box::new(resolver), ttl);
+        state.set_auth_config(Arc::new(cache), Duration::from_secs(cli.auth.auth_max_skew));
+        tracing::info!(
+            "Auth enabled (cache_ttl={}s, max_skew={}s)",
+            cli.auth.auth_cache_ttl,
+            cli.auth.auth_max_skew
+        );
+    }
+
+    state
 }
 
 async fn start_checkpoint_coordinator(

--- a/provider-node/src/fs_api.rs
+++ b/provider-node/src/fs_api.rs
@@ -46,6 +46,18 @@ fn default_root() -> String {
     "/".to_string()
 }
 
+/// Validate a user-supplied file-system path: absolute, non-empty, and free of
+/// `..` traversal segments.
+fn validate_fs_path(path: &str) -> Result<(), Error> {
+    if path.is_empty() || !path.starts_with('/') {
+        return Err(Error::InvalidPath("path must start with '/'".to_string()));
+    }
+    if path.split('/').any(|seg| seg == "..") {
+        return Err(Error::InvalidPath("path must not contain '..'".to_string()));
+    }
+    Ok(())
+}
+
 /// PUT /fs/:bucket_id/file?path=...
 ///
 /// Accepts raw bytes, chunks internally, builds Merkle tree, commits to MMR, updates FS index.
@@ -58,9 +70,7 @@ pub async fn fs_put_file(
 ) -> Result<Json<PutFileResponse>, Error> {
     check_role(&state, &headers, "PUT", bucket_id, RequiredRole::Writer).await?;
     let path = params.path;
-    if path.is_empty() || !path.starts_with('/') {
-        return Err(Error::InvalidPath("path must start with '/'".to_string()));
-    }
+    validate_fs_path(&path)?;
 
     let data = body.to_vec();
     let size = data.len() as u64;
@@ -137,6 +147,7 @@ pub async fn fs_get_file(
 ) -> Result<Response, Error> {
     check_role(&state, &headers, "GET", bucket_id, RequiredRole::Reader).await?;
     let path = params.path;
+    validate_fs_path(&path)?;
     let meta = state
         .fs_index
         .get_entry(bucket_id, &path)
@@ -187,6 +198,7 @@ pub async fn fs_delete_file(
 ) -> Result<Json<DeleteFileResponse>, Error> {
     check_role(&state, &headers, "DELETE", bucket_id, RequiredRole::Writer).await?;
     let path = params.path;
+    validate_fs_path(&path)?;
     let deleted = state.fs_index.delete_entry(bucket_id, &path).is_some();
 
     Ok(Json(DeleteFileResponse { deleted }))
@@ -203,9 +215,7 @@ pub async fn fs_mkdir(
 ) -> Result<Json<MkdirResponse>, Error> {
     check_role(&state, &headers, "POST", bucket_id, RequiredRole::Writer).await?;
     let path = params.path;
-    if path.is_empty() || !path.starts_with('/') {
-        return Err(Error::InvalidPath("path must start with '/'".to_string()));
-    }
+    validate_fs_path(&path)?;
 
     state.fs_index.mkdir(bucket_id, path.clone());
 
@@ -225,6 +235,7 @@ pub async fn fs_list_dir(
     headers: axum::http::HeaderMap,
 ) -> Result<Json<ListDirResponse>, Error> {
     check_role(&state, &headers, "GET", bucket_id, RequiredRole::Reader).await?;
+    validate_fs_path(&params.path)?;
     let entries = state
         .fs_index
         .list_dir(bucket_id, &params.path, params.recursive);

--- a/provider-node/src/lib.rs
+++ b/provider-node/src/lib.rs
@@ -98,6 +98,9 @@ pub struct ProviderState {
     /// On-chain provider registration info, kept current by the background
     /// reconciler. `None` until the provider is registered on chain.
     pub provider_info: StateProviderInfo,
+    /// Browser origins allowed via CORS. `None` (the default) keeps the
+    /// permissive policy; `Some(list)` restricts to exactly those origins.
+    pub cors_allowed_origins: Option<Vec<String>>,
 }
 
 impl ProviderState {
@@ -114,6 +117,7 @@ impl ProviderState {
             auth_max_skew: Duration::from_secs(300),
             nonce_counter: Arc::new(NonceCounter::new(1)),
             provider_info: Arc::new(RwLock::new(None)),
+            cors_allowed_origins: None,
         }
     }
 
@@ -137,6 +141,7 @@ impl ProviderState {
             auth_max_skew: Duration::from_secs(300),
             nonce_counter: Arc::new(NonceCounter::new(1)),
             provider_info: Arc::new(RwLock::new(None)),
+            cors_allowed_origins: None,
         })
     }
 

--- a/provider-node/src/lib.rs
+++ b/provider-node/src/lib.rs
@@ -85,9 +85,12 @@ pub struct ProviderState {
     pub fs_index: FsIndexManager,
     /// Channel to send commands to the checkpoint coordinator (if running).
     pub checkpoint_cmd_tx: std::sync::Mutex<Option<mpsc::Sender<CoordinatorCommand>>>,
-    /// Whether auth is enabled (opt-in).
+    /// Whether membership auth is enforced. Enforced by default at startup; the
+    /// node clears this only when started with
+    /// `--disable-auth-i-know-what-i-am-doing`.
     pub auth_enabled: bool,
-    /// Membership cache for role lookups (only set when auth is enabled).
+    /// Membership cache for role lookups. Set whenever auth is enforced (i.e.
+    /// always, unless the operator opted out via the escape-hatch flag).
     pub membership_cache: Option<Arc<auth::MembershipCache>>,
     /// Maximum allowed clock skew for request timestamps.
     pub auth_max_skew: Duration,
@@ -118,7 +121,7 @@ impl ProviderState {
             s3_index: S3IndexManager::new(),
             fs_index: FsIndexManager::new(),
             checkpoint_cmd_tx: std::sync::Mutex::new(None),
-            auth_enabled: false,
+            auth_enabled: true,
             membership_cache: None,
             auth_max_skew: Duration::from_secs(300),
             nonce_counter: Arc::new(NonceCounter::new(1)),
@@ -162,6 +165,15 @@ impl ProviderState {
         self.auth_enabled = true;
         self.membership_cache = Some(membership_cache);
         self.auth_max_skew = max_skew;
+    }
+
+    /// Turn off membership auth, leaving every endpoint publicly accessible.
+    /// Reserved for the `--disable-auth-i-know-what-i-am-doing` escape hatch and
+    /// for tests that exercise non-auth behavior.
+    pub fn with_auth_disabled(mut self) -> Self {
+        self.auth_enabled = false;
+        self.membership_cache = None;
+        self
     }
 
     /// Set the checkpoint coordinator command sender (called after coordinator starts).

--- a/provider-node/src/lib.rs
+++ b/provider-node/src/lib.rs
@@ -104,11 +104,17 @@ pub struct ProviderState {
 }
 
 impl ProviderState {
-    pub fn new(storage: Arc<dyn StorageBackend>, provider_id: String) -> Self {
+    /// Shared constructor body for [`with_provider_id`](Self::with_provider_id)
+    /// and [`with_seed`](Self::with_seed). All other fields take their defaults;
+    fn from_parts(
+        storage: Arc<dyn StorageBackend>,
+        provider_id: String,
+        keypair: Option<sr25519::Keypair>,
+    ) -> Self {
         Self {
             storage,
             provider_id,
-            keypair: None,
+            keypair,
             s3_index: S3IndexManager::new(),
             fs_index: FsIndexManager::new(),
             checkpoint_cmd_tx: std::sync::Mutex::new(None),
@@ -121,6 +127,13 @@ impl ProviderState {
         }
     }
 
+    /// Create state for a provider that cannot sign: `provider_id` is used as-is
+    /// for identity and on-chain reconciliation, and signing endpoints stay
+    /// unavailable. For a signing provider use [`with_seed`](Self::with_seed).
+    pub fn with_provider_id(storage: Arc<dyn StorageBackend>, provider_id: String) -> Self {
+        Self::from_parts(storage, provider_id, None)
+    }
+
     /// Create with a seed phrase or derivation path (e.g., "//Alice", "//Bob").
     pub fn with_seed(storage: Arc<dyn StorageBackend>, seed: &str) -> Result<Self, String> {
         let suri = subxt_signer::SecretUri::from_str(seed).expect("Failed to parse SURI");
@@ -129,20 +142,26 @@ impl ProviderState {
 
         let provider_id = keypair.public_key().to_account_id().to_string();
 
-        Ok(Self {
-            storage,
-            provider_id,
-            keypair: Some(keypair),
-            s3_index: S3IndexManager::new(),
-            fs_index: FsIndexManager::new(),
-            checkpoint_cmd_tx: std::sync::Mutex::new(None),
-            auth_enabled: false,
-            membership_cache: None,
-            auth_max_skew: Duration::from_secs(300),
-            nonce_counter: Arc::new(NonceCounter::new(1)),
-            provider_info: Arc::new(RwLock::new(None)),
-            cors_allowed_origins: None,
-        })
+        Ok(Self::from_parts(storage, provider_id, Some(keypair)))
+    }
+
+    /// Restrict the browser origins allowed via CORS. `None` (the default) keeps
+    /// the permissive policy; `Some(list)` restricts to exactly those origins.
+    pub fn with_cors_origins(mut self, origins: Option<Vec<String>>) -> Self {
+        self.cors_allowed_origins = origins;
+        self
+    }
+
+    /// Enable membership-based auth, wiring in the role-lookup cache and the
+    /// maximum tolerated clock skew for request timestamps.
+    pub fn set_auth_config(
+        &mut self,
+        membership_cache: Arc<auth::MembershipCache>,
+        max_skew: Duration,
+    ) {
+        self.auth_enabled = true;
+        self.membership_cache = Some(membership_cache);
+        self.auth_max_skew = max_skew;
     }
 
     /// Set the checkpoint coordinator command sender (called after coordinator starts).
@@ -179,7 +198,7 @@ mod tests {
         // contract is that `sign()` MUST return `Err(SigningUnavailable)`
         // when no keypair is configured, so the HTTP layer can map it to a
         // 503 instead of emitting a cryptographically invalid placeholder.
-        let state = ProviderState::new(test_storage(), "no-key-provider".to_string());
+        let state = ProviderState::with_provider_id(test_storage(), "no-key-provider".to_string());
         let err = state
             .sign(b"any message")
             .expect_err("must refuse to sign without a keypair");

--- a/provider-node/src/types.rs
+++ b/provider-node/src/types.rs
@@ -205,12 +205,13 @@ pub struct MerkleProofData {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Request to delete data (admin only).
+///
+/// Authorization is carried in the `Authorization` header (`Web3Storage …`,
+/// verified against the bucket's Admin members), not in the body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteRequest {
     pub bucket_id: BucketId,
     pub new_start_seq: u64,
-    /// Admin signature authorizing deletion
-    pub admin_signature: String,
 }
 
 /// Response from delete operation.

--- a/provider-node/tests/api_integration.rs
+++ b/provider-node/tests/api_integration.rs
@@ -31,9 +31,13 @@ impl TestServer {
     /// Endpoints that sign commitments (`/commit`, `/commitment`, ...) work
     /// because a real sr25519 keypair is available.
     async fn new() -> Self {
+        // These tests exercise endpoint behavior, not auth, so run with auth
+        // disabled (auth is enforced by default). Auth is covered end-to-end in
+        // `auth_integration.rs`.
         Self::with_state(Arc::new(
             ProviderState::with_seed(Arc::new(Storage::new()), PROVIDER_SEED)
-                .expect("//Alice is a valid SURI"),
+                .expect("//Alice is a valid SURI")
+                .with_auth_disabled(),
         ))
         .await
     }
@@ -43,10 +47,13 @@ impl TestServer {
     /// Used to verify that signing-bound endpoints return 503 rather than
     /// silently emitting zero-byte placeholder signatures.
     async fn new_unsigned() -> Self {
-        Self::with_state(Arc::new(ProviderState::with_provider_id(
-            Arc::new(Storage::new()),
-            "0xtest_provider".to_string(),
-        )))
+        Self::with_state(Arc::new(
+            ProviderState::with_provider_id(
+                Arc::new(Storage::new()),
+                "0xtest_provider".to_string(),
+            )
+            .with_auth_disabled(),
+        ))
         .await
     }
 

--- a/provider-node/tests/api_integration.rs
+++ b/provider-node/tests/api_integration.rs
@@ -43,7 +43,7 @@ impl TestServer {
     /// Used to verify that signing-bound endpoints return 503 rather than
     /// silently emitting zero-byte placeholder signatures.
     async fn new_unsigned() -> Self {
-        Self::with_state(Arc::new(ProviderState::new(
+        Self::with_state(Arc::new(ProviderState::with_provider_id(
             Arc::new(Storage::new()),
             "0xtest_provider".to_string(),
         )))

--- a/provider-node/tests/auth_integration.rs
+++ b/provider-node/tests/auth_integration.rs
@@ -9,6 +9,7 @@
 //! single end-to-end path.
 
 use axum::http::StatusCode;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use reqwest::Client;
 use serde_json::Value;
 use sp_core::{sr25519, Pair};
@@ -94,8 +95,8 @@ impl AuthTestServer {
 
         let mut state = ProviderState::with_seed(Arc::new(Storage::new()), "//Alice")
             .expect("//Alice is valid");
-        state.auth_enabled = true;
-        state.membership_cache = Some(cache);
+        // 300s skew keeps the default the `*_expired_timestamp` tests assume.
+        state.set_auth_config(cache, Duration::from_secs(300));
 
         let app = create_router(Arc::new(state));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -520,6 +521,130 @@ async fn delete_missing_auth_returns_401() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// L0 node / commit endpoint auth tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build an `UploadNodeRequest` body for `bucket_id` storing `data`.
+fn node_body(bucket_id: u64, data: &[u8]) -> Value {
+    let hash = storage_primitives::blake2_256(data);
+    serde_json::json!({
+        "bucket_id": bucket_id,
+        "hash": format!("0x{}", hex_encode(hash.as_bytes())),
+        "data": BASE64.encode(data),
+    })
+}
+
+#[tokio::test]
+async fn node_writer_can_upload() {
+    let server = AuthTestServer::with_role(Role::Writer).await;
+    let alice = sr25519::Pair::from_string("//Alice", None).unwrap();
+
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "PUT", 1, ts);
+    let resp = server
+        .client
+        .put(server.url("/node"))
+        .header("Authorization", &header)
+        .json(&node_body(1, b"writer node payload"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn node_reader_blocked() {
+    let server = AuthTestServer::with_role(Role::Reader).await;
+    let alice = sr25519::Pair::from_string("//Alice", None).unwrap();
+
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "PUT", 1, ts);
+    let resp = server
+        .client
+        .put(server.url("/node"))
+        .header("Authorization", &header)
+        .json(&node_body(1, b"reader cannot write"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn node_missing_auth_returns_401() {
+    let server = AuthTestServer::with_role(Role::Writer).await;
+
+    let resp = server
+        .client
+        .put(server.url("/node"))
+        .json(&node_body(1, b"no auth header"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn commit_writer_can_commit() {
+    let server = AuthTestServer::with_role(Role::Writer).await;
+    let alice = sr25519::Pair::from_string("//Alice", None).unwrap();
+
+    // Upload a node first (Writer), then commit it.
+    let data = b"committed chunk";
+    let hash_hex = format!(
+        "0x{}",
+        hex_encode(storage_primitives::blake2_256(data).as_bytes())
+    );
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "PUT", 1, ts);
+    server
+        .client
+        .put(server.url("/node"))
+        .header("Authorization", &header)
+        .json(&node_body(1, data))
+        .send()
+        .await
+        .unwrap();
+
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "POST", 1, ts);
+    let resp = server
+        .client
+        .post(server.url("/commit"))
+        .header("Authorization", &header)
+        .json(&serde_json::json!({ "bucket_id": 1, "data_roots": [hash_hex] }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["provider_signature"].is_string());
+}
+
+#[tokio::test]
+async fn commit_reader_blocked() {
+    let server = AuthTestServer::with_role(Role::Reader).await;
+    let alice = sr25519::Pair::from_string("//Alice", None).unwrap();
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "POST", 1, ts);
+
+    let resp = server
+        .client
+        .post(server.url("/commit"))
+        .header("Authorization", &header)
+        .json(&serde_json::json!({ "bucket_id": 1, "data_roots": [] }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/provider-node/tests/auth_integration.rs
+++ b/provider-node/tests/auth_integration.rs
@@ -451,6 +451,78 @@ async fn s3_head_with_auth() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Delete endpoint auth tests (admin-only)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn delete_admin_can_prune() {
+    let server = AuthTestServer::with_role(Role::Admin).await;
+    let alice = sr25519::Pair::from_string("//Alice", None).unwrap();
+
+    // Create bucket 1 by uploading a file (Admin satisfies the Writer requirement).
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "PUT", 1, ts);
+    server
+        .client
+        .put(server.url("/fs/1/file?path=/data.txt"))
+        .header("Authorization", &header)
+        .body(b"prune me".to_vec())
+        .send()
+        .await
+        .unwrap();
+
+    // Admin-signed delete succeeds.
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "POST", 1, ts);
+    let resp = server
+        .client
+        .post(server.url("/delete"))
+        .header("Authorization", &header)
+        .json(&serde_json::json!({ "bucket_id": 1, "new_start_seq": 0 }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["provider_signature"].is_string());
+}
+
+#[tokio::test]
+async fn delete_writer_blocked() {
+    let server = AuthTestServer::with_role(Role::Writer).await;
+    let alice = sr25519::Pair::from_string("//Alice", None).unwrap();
+    let ts = current_timestamp();
+    let header = make_auth_header(&alice, "POST", 1, ts);
+
+    let resp = server
+        .client
+        .post(server.url("/delete"))
+        .header("Authorization", &header)
+        .json(&serde_json::json!({ "bucket_id": 1, "new_start_seq": 0 }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn delete_missing_auth_returns_401() {
+    let server = AuthTestServer::with_role(Role::Admin).await;
+
+    let resp = server
+        .client
+        .post(server.url("/delete"))
+        .json(&serde_json::json!({ "bucket_id": 1, "new_start_seq": 0 }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/provider-node/tests/coordinators/challenge.rs
+++ b/provider-node/tests/coordinators/challenge.rs
@@ -178,7 +178,10 @@ fn test_state_with_data() -> (Arc<ProviderState>, DetectedChallenge) {
         created_at_block: 900,
     };
 
-    let state = Arc::new(ProviderState::new(storage, ALICE_SS58.to_string()));
+    let state = Arc::new(ProviderState::with_provider_id(
+        storage,
+        ALICE_SS58.to_string(),
+    ));
     (state, challenge)
 }
 

--- a/provider-node/tests/coordinators/main.rs
+++ b/provider-node/tests/coordinators/main.rs
@@ -18,7 +18,10 @@ pub const ALICE_SEED: &str = "//Alice";
 /// Create a standard test `ProviderState` for coordinator tests.
 pub fn test_state() -> Arc<ProviderState> {
     let storage = Arc::new(Storage::new());
-    Arc::new(ProviderState::new(storage, ALICE_SS58.to_string()))
+    Arc::new(ProviderState::with_provider_id(
+        storage,
+        ALICE_SS58.to_string(),
+    ))
 }
 
 /// Create a test `ProviderState` with a keypair derived from the given seed.

--- a/provider-node/tests/coordinators/replica_sync.rs
+++ b/provider-node/tests/coordinators/replica_sync.rs
@@ -156,7 +156,7 @@ async fn test_already_synced() {
     let _ = storage.store_node(1, data_root, data, None);
     let (mmr_root, _, _) = storage.commit(1, vec![data_root]).unwrap();
 
-    let state = Arc::new(ProviderState::new(storage, "test".to_string()));
+    let state = Arc::new(ProviderState::with_provider_id(storage, "test".to_string()));
 
     let duty = SyncDuty {
         bucket_id: 1,
@@ -364,7 +364,10 @@ async fn test_duties_filter_already_synced() {
     storage.store_node(1, data_root, data, None).unwrap();
     let (mmr_root, _, _) = storage.commit(1, vec![data_root]).unwrap();
 
-    let state = Arc::new(ProviderState::new(storage, ALICE_SS58.to_string()));
+    let state = Arc::new(ProviderState::with_provider_id(
+        storage,
+        ALICE_SS58.to_string(),
+    ));
 
     let agreement = ReplicaAgreementInfo {
         bucket_id: 1,

--- a/provider-node/tests/disk_integration.rs
+++ b/provider-node/tests/disk_integration.rs
@@ -26,8 +26,12 @@ impl DiskTestServer {
     async fn new() -> Self {
         let dir = TempDir::new().unwrap();
         let disk = DiskStorage::new(dir.path()).expect("RocksDB should open");
+        // Functional tests, not auth tests: run with auth disabled (auth is
+        // enforced by default; see auth_integration.rs for the auth coverage).
         let state = Arc::new(
-            ProviderState::with_seed(Arc::new(disk), "//Alice").expect("//Alice is valid"),
+            ProviderState::with_seed(Arc::new(disk), "//Alice")
+                .expect("//Alice is valid")
+                .with_auth_disabled(),
         );
 
         let app = create_router(state);

--- a/provider-node/tests/fs_integration.rs
+++ b/provider-node/tests/fs_integration.rs
@@ -18,7 +18,10 @@ struct TestServer {
 impl TestServer {
     async fn new() -> Self {
         let storage = Arc::new(Storage::new());
-        let state = Arc::new(ProviderState::new(storage, "0xtest_provider".to_string()));
+        let state = Arc::new(ProviderState::with_provider_id(
+            storage,
+            "0xtest_provider".to_string(),
+        ));
 
         let app = create_router(state);
 

--- a/provider-node/tests/fs_integration.rs
+++ b/provider-node/tests/fs_integration.rs
@@ -18,10 +18,12 @@ struct TestServer {
 impl TestServer {
     async fn new() -> Self {
         let storage = Arc::new(Storage::new());
-        let state = Arc::new(ProviderState::with_provider_id(
-            storage,
-            "0xtest_provider".to_string(),
-        ));
+        // Functional tests, not auth tests: run with auth disabled (auth is
+        // enforced by default; see auth_integration.rs for the auth coverage).
+        let state = Arc::new(
+            ProviderState::with_provider_id(storage, "0xtest_provider".to_string())
+                .with_auth_disabled(),
+        );
 
         let app = create_router(state);
 

--- a/provider-node/tests/fs_integration.rs
+++ b/provider-node/tests/fs_integration.rs
@@ -352,6 +352,37 @@ async fn test_fs_put_invalid_path() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Path traversal (`..`) rejected on every fs endpoint → 400
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_fs_rejects_path_traversal() {
+    let server = TestServer::new().await;
+
+    // Each tuple is (HTTP method, URL) for a path containing `..`.
+    let put = server
+        .client
+        .put(server.url("/fs/1/file?path=/../../etc/passwd"));
+    let get = server.client.get(server.url("/fs/1/file?path=/../secret"));
+    let del = server
+        .client
+        .delete(server.url("/fs/1/file?path=/a/../../b"));
+    let mkdir = server.client.post(server.url("/fs/1/mkdir?path=/x/../y"));
+    let ls = server.client.get(server.url("/fs/1/ls?path=/../"));
+
+    for req in [put, get, del, mkdir, ls] {
+        let resp = req.body("data").send().await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "path containing '..' must be rejected"
+        );
+        let body: Value = resp.json().await.unwrap();
+        assert_eq!(body["error"], "invalid_path");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Overwrite
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/provider-node/tests/negotiate_integration.rs
+++ b/provider-node/tests/negotiate_integration.rs
@@ -206,7 +206,7 @@ async fn negotiate_accepts_replica_when_sync_price_configured() {
 #[tokio::test]
 async fn negotiate_503_when_no_signing_key() {
     // No keypair configured → the handler refuses before doing any work.
-    let server = TestServer::serve(Arc::new(ProviderState::new(
+    let server = TestServer::serve(Arc::new(ProviderState::with_provider_id(
         Arc::new(Storage::new()),
         "0xtest_provider".to_string(),
     )))

--- a/provider-node/tests/s3_integration.rs
+++ b/provider-node/tests/s3_integration.rs
@@ -18,7 +18,10 @@ struct TestServer {
 impl TestServer {
     async fn new() -> Self {
         let storage = Arc::new(Storage::new());
-        let state = Arc::new(ProviderState::new(storage, "0xtest_provider".to_string()));
+        let state = Arc::new(ProviderState::with_provider_id(
+            storage,
+            "0xtest_provider".to_string(),
+        ));
 
         let app = create_router(state);
 

--- a/provider-node/tests/s3_integration.rs
+++ b/provider-node/tests/s3_integration.rs
@@ -18,10 +18,12 @@ struct TestServer {
 impl TestServer {
     async fn new() -> Self {
         let storage = Arc::new(Storage::new());
-        let state = Arc::new(ProviderState::with_provider_id(
-            storage,
-            "0xtest_provider".to_string(),
-        ));
+        // Functional tests, not auth tests: run with auth disabled (auth is
+        // enforced by default; see auth_integration.rs for the auth coverage).
+        let state = Arc::new(
+            ProviderState::with_provider_id(storage, "0xtest_provider".to_string())
+                .with_auth_disabled(),
+        );
 
         let app = create_router(state);
 


### PR DESCRIPTION
Resolves S1, S2, and S3 flagged in this audit: https://github.com/paritytech/web3-storage/issues/149

S1 — Authenticate POST /delete
  
  The delete endpoint pruned bucket data but never authenticated the caller (let _ = request.admin_signature), so anyone could permanently prune a bucket.
  Now requires an Admin-signed request via the existing check_role header-auth path used by every other mutating endpoint.

  S2 — Configurable CORS
  
  Replaces the hardcoded CorsLayer::permissive() with a --cors-allowed-origins / CORS_ALLOWED_ORIGINS option threaded through ProviderState. Default stays
  permissive (local dev / demos / UIs unchanged); operators can restrict to trusted origins in production.

  S3 — Reject .. in file-system paths

  Adds a shared validate_fs_path helper (absolute, non-empty, no ..) applied to all five fs handlers — previously get/delete/list did no validation.
  Defense-in-depth: fs paths are content-index keys (RocksDB / in-memory), not real filesystem paths, so this isn't an active filesystem-escape.

---
<!-- roadmap-tracking -->
_Closes #226 — cross-repo roadmap tracking._
