### PR TITLE
Bound the Challenges storage map

### DIFF
--- a/pallet/src/benchmarking.rs
+++ b/pallet/src/benchmarking.rs
@@ -222,7 +222,8 @@ fn insert_challenge<T: Config>(
         chunk_index: 0,
         deposit: 100u32.into(),
     };
-    Challenges::<T>::insert(deadline, alloc::vec![challenge]);
+    let challenges = BoundedVec::truncate_from(alloc::vec![challenge]);
+    Challenges::<T>::insert(deadline, challenges);
     storage_primitives::ChallengeId { deadline, index: 0 }
 }
 

--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -149,6 +149,10 @@ pub mod pallet {
         #[pallet::constant]
         type MaxBucketsPerMember: Get<u32>;
 
+        /// Maximum number of challenges that can share a single deadline block.
+        #[pallet::constant]
+        type MaxChallengesPerBlock: Get<u32>;
+
         /// Minimum number of blocks between announcing a deregistration and
         /// being allowed to complete it. Must be `>= ChallengeTimeout` so any
         /// challenge against this provider that was created up to the
@@ -201,10 +205,13 @@ pub mod pallet {
 
     /// Pending challenges indexed by deadline block.
     #[pallet::storage]
-    #[pallet::unbounded]
     #[pallet::getter(fn challenges)]
-    pub type Challenges<T: Config> =
-        StorageMap<_, Blake2_128Concat, BlockNumberFor<T>, Vec<Challenge<T>>>;
+    pub type Challenges<T: Config> = StorageMap<
+        _,
+        Blake2_128Concat,
+        BlockNumberFor<T>,
+        BoundedVec<Challenge<T>, T::MaxChallengesPerBlock>,
+    >;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Provider-Initiated Checkpoint Storage
@@ -839,6 +846,8 @@ pub mod pallet {
         ProviderNotInSnapshot,
         LeafBeyondCanonical,
         InvalidDeletionProof,
+        /// Too many challenges already share this deadline block.
+        TooManyChallenges,
 
         // Checkpoint errors
         InvalidSignature,
@@ -3239,12 +3248,17 @@ pub mod pallet {
                 deposit,
             };
 
-            let index = Challenges::<T>::mutate(deadline, |challenges| {
-                let challenges = challenges.get_or_insert_with(Vec::new);
-                let idx = challenges.len() as u16;
-                challenges.push(challenge);
-                idx
-            });
+            let index = Challenges::<T>::try_mutate(
+                deadline,
+                |challenges| -> Result<u16, DispatchError> {
+                    let challenges = challenges.get_or_insert_with(Default::default);
+                    let idx = challenges.len() as u16;
+                    challenges
+                        .try_push(challenge)
+                        .map_err(|_| Error::<T>::TooManyChallenges)?;
+                    Ok(idx)
+                },
+            )?;
 
             // Update provider stats
             Providers::<T>::mutate(&provider, |maybe_provider| {

--- a/pallet/src/mock.rs
+++ b/pallet/src/mock.rs
@@ -94,6 +94,7 @@ impl pallet_storage_provider::Config for Test {
     type CheckpointReward = ConstU64<10>; // 10 units reward
     type CheckpointMissPenalty = ConstU64<50>; // 50 units penalty
     type MaxBucketsPerMember = ConstU32<100>;
+    type MaxChallengesPerBlock = ConstU32<1024>;
     // Must be >= ChallengeTimeout (100 in this mock). Set to a small
     // multiple so tests can advance past the period quickly.
     type DeregisterAnnouncementPeriod = ConstU64<100>;

--- a/pallet/src/tests/challenge.rs
+++ b/pallet/src/tests/challenge.rs
@@ -608,3 +608,36 @@ fn respond_to_challenge_superseded_emits_defended_event() {
             .any(|r| r.event == expected_event));
     });
 }
+
+#[test]
+fn challenge_rejected_when_deadline_full() {
+    new_test_ext().execute_with(|| {
+        frame_system::Pallet::<Test>::set_block_number(1);
+        let bucket_id = setup_with_snapshot(2, 1);
+
+        // A challenge created at block 1 matures at deadline 1 + ChallengeTimeout(100) = 101.
+        // Fill that deadline's list to capacity (MaxChallengesPerBlock) so the next push overflows.
+        let dummy = Challenge::<Test> {
+            bucket_id,
+            provider: 2,
+            challenger: 3,
+            mmr_root: H256::repeat_byte(0xAB),
+            start_seq: 0,
+            leaf_index: 0,
+            chunk_index: 0,
+            deposit: 100,
+        };
+        let mut full = frame_support::BoundedVec::<
+            Challenge<Test>,
+            <Test as Config>::MaxChallengesPerBlock,
+        >::new();
+        while full.try_push(dummy.clone()).is_ok() {}
+        Challenges::<Test>::insert(101, full);
+
+        // The next challenge for the same deadline is rejected (and the deposit is rolled back).
+        assert_noop!(
+            StorageProvider::challenge_checkpoint(RuntimeOrigin::signed(3), bucket_id, 2, 0, 0),
+            Error::<Test>::TooManyChallenges
+        );
+    });
+}

--- a/runtimes/web3-storage-local/src/storage.rs
+++ b/runtimes/web3-storage-local/src/storage.rs
@@ -83,6 +83,7 @@ impl pallet_storage_provider::Config for Runtime {
     type CheckpointReward = CheckpointReward;
     type CheckpointMissPenalty = CheckpointMissPenalty;
     type MaxBucketsPerMember = ConstU32<1000>;
+    type MaxChallengesPerBlock = ConstU32<1024>;
     type DeregisterAnnouncementPeriod = DeregisterAnnouncementPeriod;
     type WeightInfo = crate::weights::pallet_storage_provider::WeightInfo<Runtime>;
 }

--- a/runtimes/web3-storage-paseo/src/storage.rs
+++ b/runtimes/web3-storage-paseo/src/storage.rs
@@ -89,6 +89,7 @@ impl pallet_storage_provider::Config for Runtime {
     type CheckpointReward = CheckpointReward;
     type CheckpointMissPenalty = CheckpointMissPenalty;
     type MaxBucketsPerMember = ConstU32<1000>;
+    type MaxChallengesPerBlock = ConstU32<1024>;
     type DeregisterAnnouncementPeriod = DeregisterAnnouncementPeriod;
     type WeightInfo = crate::weights::pallet_storage_provider::WeightInfo<Runtime>;
 }

--- a/storage-interfaces/file-system/pallet-registry/src/mock.rs
+++ b/storage-interfaces/file-system/pallet-registry/src/mock.rs
@@ -98,6 +98,7 @@ impl pallet_storage_provider::Config for Test {
     type MaxMembers = MaxMembers;
     type MaxPrimaryProviders = MaxPrimaryProviders;
     type MaxBucketsPerMember = ConstU32<100>;
+    type MaxChallengesPerBlock = ConstU32<1024>;
     type MinProviderStake = MinProviderStake;
     type MaxChunkSize = MaxChunkSize;
     type ChallengeTimeout = ChallengeTimeout;

--- a/storage-interfaces/s3/pallet-s3-registry/src/mock.rs
+++ b/storage-interfaces/s3/pallet-s3-registry/src/mock.rs
@@ -98,6 +98,7 @@ impl pallet_storage_provider::Config for Test {
     type MaxMembers = ConstU32<100>;
     type MaxPrimaryProviders = ConstU32<5>;
     type MaxBucketsPerMember = ConstU32<100>;
+    type MaxChallengesPerBlock = ConstU32<1024>;
     type MinProviderStake = MinProviderStake;
     type MaxChunkSize = ConstU32<262144>;
     type ChallengeTimeout = ChallengeTimeout;


### PR DESCRIPTION
Convert the value of `Challenges[n]`to `BoundedVec<Challenge<T>, T::MaxChallengesPerBlock>`.
Flagged by audit here: https://github.com/paritytech/web3-storage/issues/149 as P1.