### PR TITLE
ci: run required checks on merge_group for merge queue support

### DIFF
--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -12,6 +12,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 5 * * *' # Daily at 5 AM UTC — refresh cached snapshots
@@ -37,12 +38,14 @@ jobs:
     permissions:
       contents: read
     outputs:
-      runtime: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || steps.filter.outputs.runtime == 'true' }}
+      runtime: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || steps.filter.outputs.runtime == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+      # paths-filter has no diff base on merge_group; run the full suite there.
+      - if: github.event_name != 'merge_group'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -25,12 +26,14 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.rust == 'true' }}
+      rust: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || steps.filter.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+      # paths-filter has no diff base on merge_group; run the full suite there.
+      - if: github.event_name != 'merge_group'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -24,12 +25,14 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      src: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.src == 'true' }}
+      src: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || steps.filter.outputs.src == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+      # paths-filter has no diff base on merge_group; run the full suite there.
+      - if: github.event_name != 'merge_group'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  merge_group:
   # Daily re-scan of unchanged code for newly-published advisories / leaks.
   schedule:
     - cron: '17 6 * * *' # daily at 06:17 UTC
@@ -43,7 +44,7 @@ jobs:
       # Advisory DB drifts over time, so keep it non-blocking on PRs.
       - name: Check advisories
         run: cargo deny --locked check advisories
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
   # gitleaks is not in ci-unified and needs no Rust toolchain — run it standalone.
   gitleaks:

--- a/.github/workflows/ui-checks.yml
+++ b/.github/workflows/ui-checks.yml
@@ -8,6 +8,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -22,12 +23,14 @@ jobs:
     name: Detect UI changes
     runs-on: ubuntu-latest
     outputs:
-      ui: ${{ steps.filter.outputs.ui }}
+      ui: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || steps.filter.outputs.ui == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+      # paths-filter has no diff base on merge_group; run the full suite there.
+      - if: github.event_name != 'merge_group'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,6 +9,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,9 @@
 - NEVER use git rebase
 - NEVER use git push --force or git push -f
 
+**Pull request rules:**
+- ALWAYS open pull requests against the repository's default branch (`dev`)
+
 **Automatic formatting:**
 - ALWAYS run `/format` after generating or modifying Rust code
 - ALWAYS run `/format` before creating any git commit


### PR DESCRIPTION
## What

Adds a `merge_group:` trigger to every workflow that produces a required status check, so they run on the merge queue's temporary `gh-readonly-queue/...` branches. This is the prerequisite for enabling GitHub's **merge queue** on `main`/`dev`.

Without it, queued PRs would never receive a result for the required checks and the queue would stall.

## Workflows changed

| Workflow | Required gate check |
|---|---|
| `check.yml` | Basic checks |
| `integration-tests.yml` | Integration Tests |
| `ui-checks.yml` | UI Checks |
| `check-runtime-migration.yml` | All migrations passed |
| `security.yml` | Security |
| `zizmor.yml` | Audit workflows |

## Path-filter handling

The four workflows with a `changes` job use `dorny/paths-filter`, which has **no diff base on `merge_group`** (the event carries no before/after to diff). For those I:

- added `|| github.event_name == 'merge_group'` to the `changes` output so the **full suite runs** in the queue (treated like `workflow_dispatch`), and
- guarded the paths-filter step with `if: github.event_name != 'merge_group'` so it isn't run without a base (which would fail the `changes` job and cascade into the `if: always()` gate).

Running everything is the correct behavior for the queue — it's the single, final validation of the exact commits about to land, so skipping checks there would defeat the purpose. It runs at most once per merge.

`security.yml` additionally keeps the `cargo deny check advisories` step non-blocking on `merge_group`, mirroring its existing `pull_request` behavior so advisory-DB drift doesn't block the queue.

The aggregate gate jobs (`if: always()`) were already correct and needed no change.

## Follow-up (repo settings, needs admin)

After merge, enable **Require merge queue** on `main` and `dev` (Settings → Rules/Branches) and select the six gate checks above as required.

## Testing notes

`merge_group` can't be fully exercised until the queue is enabled on the repo. This PR confirms the workflows still parse and run correctly on `pull_request`.