### PR TITLE
chore(deps): inherit external dependencies from the workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@
 **Pull request rules:**
 - ALWAYS open pull requests against the repository's default branch (`dev`)
 
+**Cargo dependency rules:**
+- ALWAYS declare external dependencies in the root `[workspace.dependencies]` and inherit them in crates via `{ workspace = true }`. Never add inline-versioned dependencies (e.g. `foo = "1.2"`) to a crate's `Cargo.toml`.
+- On the inheriting line you may only add `features` (additive) and `optional`; per Cargo, `version` and `default-features` cannot appear there, so set `default-features` in the workspace declaration (e.g. `hex = { version = "0.4", default-features = false }`).
+
 **Automatic formatting:**
 - ALWAYS run `/format` after generating or modifying Rust code
 - ALWAYS run `/format` before creating any git commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ parachain-info = { version = "0.26.0", default-features = false, package = "stag
 parachains-common = { version = "28.0.0", default-features = false }
 
 # Build dependencies
+prost-build = "0.13"
 substrate-wasm-builder = { version = "32.0.0" }
 
 # Codec
@@ -130,21 +131,36 @@ scale-info = { version = "2.11.6", default-features = false, features = [
 ] }
 
 # External dependencies
+async-trait = "0.1"
+base64 = "0.22"
+bincode = "1.3"
+clap = { version = "4" }
+futures = "0.3"
+hex = { version = "0.4", default-features = false }
+prost = "0.13"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 serde_with = { version = "3.20.0" }
+thiserror = "2.0"
 tracing = { version = "0.1.41", default-features = false }
 tracing-subscriber = { version = "=0.3.19" }
 
 # Async/HTTP (for provider node)
 axum = "0.7"
+dashmap = "6.0"
+parking_lot = "0.12"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rocksdb = { version = "0.22", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
+tokio-rate-limit = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # Crypto
+bip39 = "2.0"
 blake2 = { version = "0.10", default-features = false }
+chacha20poly1305 = "0.10"
+rand = "0.8"
 
 # Subxt (chain interaction for off-chain clients)
 subxt = { version = "0.44.3" }
@@ -153,6 +169,8 @@ subxt-signer = { version = "0.44.3", features = ["sr25519"] }
 # Testing
 sp-keyring = { version = "46.0.0", default-features = false }
 sp-keystore = { version = "0.46.0", default-features = false }
+tempfile = "3"
+tokio-test = "0.4"
 
 [profile.release]
 opt-level = 3

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,20 +17,20 @@ serde_with = { workspace = true }
 sp-core = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
 tokio = { workspace = true }
-base64 = "0.22"
-thiserror = "2.0"
+base64 = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-rand = "0.8"
-chacha20poly1305 = "0.10"
-hex = "0.4"
-async-trait = "0.1"
+rand = { workspace = true }
+chacha20poly1305 = { workspace = true }
+hex = { workspace = true, features = ["std"] }
+async-trait = { workspace = true }
 subxt = { workspace = true }
 subxt-signer = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 storage-provider-node = { workspace = true }
 axum = { workspace = true }
-tempfile = "3.10"
+tempfile = { workspace = true }

--- a/provider-node/Cargo.toml
+++ b/provider-node/Cargo.toml
@@ -13,28 +13,28 @@ storage-primitives = { workspace = true, features = ["serde", "std"] }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
-tokio-rate-limit = { version = "0.8" }
+tokio-rate-limit = { workspace = true }
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 sp-core = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
 subxt = { workspace = true }
 subxt-signer = { workspace = true }
-base64 = "0.22"
-thiserror = "2.0"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-parking_lot = "0.12"
-dashmap = "6.0"
-rocksdb = { version = "0.22", default-features = false }
-bincode = "1.3"
-hex = "0.4"
-clap = { version = "4", features = ["derive", "env"] }
+base64 = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+parking_lot = { workspace = true }
+dashmap = { workspace = true }
+rocksdb = { workspace = true }
+bincode = { workspace = true }
+hex = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = ["derive", "env"] }
 reqwest = { workspace = true }
 codec = { workspace = true, features = ["std"] }
-async-trait = "0.1"
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util", "time"] }
 serde_json = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }

--- a/storage-interfaces/file-system/client/Cargo.toml
+++ b/storage-interfaces/file-system/client/Cargo.toml
@@ -26,11 +26,11 @@ subxt-signer = { workspace = true }
 # Utilities
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-thiserror = "2.0"
-hex = "0.4"
+thiserror = { workspace = true }
+hex = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-tokio-test = "0.4"
+tokio-test = { workspace = true }
 
 [[example]]
 name = "basic_usage"

--- a/storage-interfaces/file-system/primitives/Cargo.toml
+++ b/storage-interfaces/file-system/primitives/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 
 [dependencies]
 # Serialization (std only - for protobuf)
-prost = { version = "0.13", optional = true }
+prost = { workspace = true, optional = true }
 
 # Substrate/Polkadot primitives
 codec = { workspace = true }
@@ -18,13 +18,13 @@ sp-runtime = { workspace = true }
 serde = { workspace = true, optional = true }
 
 # Utilities
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
+hex = { workspace = true, features = ["alloc"] }
 
 # Error handling (std only)
-thiserror = { version = "1.0", optional = true }
+thiserror = { workspace = true, optional = true }
 
 [build-dependencies]
-prost-build = "0.13"
+prost-build = { workspace = true }
 
 [[example]]
 name = "basic_usage"

--- a/storage-interfaces/s3/client/Cargo.toml
+++ b/storage-interfaces/s3/client/Cargo.toml
@@ -23,16 +23,16 @@ tokio = { workspace = true }
 # Subxt for chain interaction
 subxt = { workspace = true }
 subxt-signer = { workspace = true }
-bip39 = "2.0"
+bip39 = { workspace = true }
 
 # Utilities
-hex = "0.4"
-thiserror = "2.0"
+hex = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full", "macros"] }
+tokio = { workspace = true }
 
 [[example]]
 name = "basic_usage"

--- a/storage-interfaces/s3/primitives/Cargo.toml
+++ b/storage-interfaces/s3/primitives/Cargo.toml
@@ -12,7 +12,7 @@ codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-hex = { version = "0.4", default-features = false, optional = true }
+hex = { workspace = true, optional = true }
 
 [dev-dependencies]
 


### PR DESCRIPTION
## Summary

Moves inline-versioned external dependencies out of individual crate manifests into the root `[workspace.dependencies]` table, inheriting them via `{ workspace = true }`, for consistent and centrally-managed versions.

Closes #154

## Changes

**Root `Cargo.toml`** — added entries to `[workspace.dependencies]`:
`async-trait`, `base64`, `bincode`, `bip39`, `chacha20poly1305`, `clap`, `dashmap`, `futures`, `hex`, `parking_lot`, `prost`, `prost-build`, `rand`, `rocksdb`, `tempfile`, `thiserror`, `tokio-rate-limit`, `tokio-test`.
(`tracing` / `tracing-subscriber` were already in the workspace — `provider-node` now inherits them instead of declaring inline.)

**Crates converted from inline versions to `{ workspace = true }`:**
- `provider-node`
- `client`
- `storage-interfaces/file-system/client`
- `storage-interfaces/file-system/primitives`
- `storage-interfaces/s3/client`
- `storage-interfaces/s3/primitives`

The 9 other workspace crates already inherited all of their dependencies — unchanged.

### Notable details
- **`thiserror` unified to `2.0`.** `file-system-primitives` was pinned to `1.0`; there it is `std`-only (gated behind the `std` feature, using only static/`{0}` error messages — no `#[from]`/`transparent`), and `2.0.18` was already resolved in the graph via subxt/alloy. The lockfile change is therefore a single line (`file-system-primitives` → `thiserror 2.0.18`).
- **`default-features` stays in the workspace declaration** for `hex` and `rocksdb`. Per the Cargo reference, an inheriting line may only add `features`/`optional` — `version` and `default-features` are not allowed there. Crates that need std add `features = ["std"]`.
- Documented the convention in `CLAUDE.md` (per the request in the issue thread).

## Verification
- `cargo check --workspace` ✓
- `cargo check -p file-system-primitives --no-default-features` ✓ (no_std / on-chain path)
- `cargo check -p s3-primitives --no-default-features` ✓
- `cargo +nightly fmt --all`, `taplo format`, `zepter run` (feature propagation) ✓
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` ✓
  (run with `SKIP_PALLET_REVIVE_FIXTURES=1` — `resolc` is not installed in the local env; unrelated to this change)
