### PR TITLE
ci(dependabot): target pnpm workspace root so the lockfile is regenerated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,36 +9,23 @@ updates:
     ignore:
       - dependency-name: "*"
 
+  # Single pnpm workspace: one lockfile at the repo root covers every member
+  # (user-interfaces/*, packages/*, examples/papi). Dependabot must target the
+  # root `/` so it regenerates that one pnpm-lock.yaml in the same PR; pointing
+  # at subdirectories bumps their package.json but leaves the root lockfile
+  # stale, which breaks CI's `pnpm install --frozen-lockfile`.
   - package-ecosystem: "npm"
-    directories:
-      - "/user-interfaces"
-      - "/user-interfaces/**"
+    directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
     groups:
-      user-interfaces-deps:
+      npm-deps:
         applies-to: version-updates
         patterns:
           - "*"
-      user-interfaces-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
-
-  - package-ecosystem: "npm"
-    directory: "/examples/papi"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    groups:
-      examples-deps:
-        applies-to: version-updates
-        patterns:
-          - "*"
-      examples-security:
+      npm-security:
         applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Problem

Every grouped npm bump from Dependabot (e.g. #242) lands red with:

```
ERR_PNPM_OUTDATED_LOCKFILE: pnpm-lock.yaml is not up to date with .../package.json
  specifiers in the lockfile don't match specifiers in package.json
```

This repo is a **single pnpm workspace** with exactly one lockfile at the repo root (`/pnpm-lock.yaml`) covering every member (`user-interfaces/*`, `packages/*`, `examples/papi`). There are no per-subdir lockfiles.

The npm Dependabot config pointed at **subdirectories** (`/user-interfaces`, `/user-interfaces/**`, `/examples/papi`). Dependabot bumped the specifiers in each subdir's `package.json` but had no lockfile there to update and never touched the root one — so the root lockfile drifted and CI's `pnpm install --frozen-lockfile` (in `.github/actions/setup-pnpm`) correctly refused to install.

## Fix

Collapse the two subdir-targeted npm entries into a single entry at `directory: "/"` — the workspace root, where the lockfile and `pnpm-workspace.yaml` live. Dependabot now discovers every member's manifest and regenerates the one root lockfile **in the same PR**, so `--frozen-lockfile` passes.

Side effects:
- All JS deps (UIs, `packages/*`, `examples/papi`) now arrive in one grouped PR instead of two — the natural shape for a single-lockfile workspace.
- Groups renamed `user-interfaces-*`/`examples-*` → `npm-*` since they're no longer scoped to one subdir.

## Validation plan

After merge, re-trigger the npm bump (recreate #242 / `@dependabot recreate`) and confirm the new PR includes an updated `pnpm-lock.yaml` and goes green without manual intervention.